### PR TITLE
Extended manifest validation fix #57

### DIFF
--- a/generators/content/templates/common/gulpfile.js
+++ b/generators/content/templates/common/gulpfile.js
@@ -24,15 +24,17 @@ gulp.task('validate-xml', function () {
   var xmlFilePath = options.xmlfile || './manifest.xml';
   var resultsAsJson = options.json || false;
   var xml = fs.readFileSync(xmlFilePath);
-  
+
   if (!resultsAsJson) {
     console.log('\nValidating ' + chalk.blue(xmlFilePath.substring(xmlFilePath.lastIndexOf('/')+1)) + ':');
-  } 
+  }
   var result = xmllint.validateXML({
     xml: xml,
     schema: xsd
   });
-  
+
+  validateHighResolutionIconUrl(xml, result);
+
   if (resultsAsJson) {
     console.log(JSON.stringify(result));
   }
@@ -48,3 +50,16 @@ gulp.task('validate-xml', function () {
     }
   }
 });
+
+function validateHighResolutionIconUrl(xml, result) {
+  if (xml && result) {
+    if (xml.indexOf('<HighResolutionIconUrl ') > -1 &&
+      xml.indexOf('<HighResolutionIconUrl DefaultValue="https://') < 0) {
+        if (result.errors === null) {
+          result.errors = [];
+        }
+        
+        result.errors.push('The value of the HighResolutionIconUrl attribute contains an unsupported URL. You can only use https:// URLs.');
+    }
+  }
+}

--- a/generators/mail/templates/common/gulpfile.js
+++ b/generators/mail/templates/common/gulpfile.js
@@ -25,6 +25,8 @@ gulp.task('validate-xml', function () {
   var resultsAsJson = options.json || false;
   var xml = fs.readFileSync(xmlFilePath);
   
+  validateHighResolutionIconUrl(xml, result);
+  
   if (!resultsAsJson) {
     console.log('\nValidating ' + chalk.blue(xmlFilePath.substring(xmlFilePath.lastIndexOf('/')+1)) + ':');
   } 
@@ -48,3 +50,16 @@ gulp.task('validate-xml', function () {
     }
   }
 });
+
+function validateHighResolutionIconUrl(xml, result) {
+  if (xml && result) {
+    if (xml.indexOf('<HighResolutionIconUrl ') > -1 &&
+      xml.indexOf('<HighResolutionIconUrl DefaultValue="https://') < 0) {
+        if (result.errors === null) {
+          result.errors = [];
+        }
+        
+        result.errors.push('The value of the HighResolutionIconUrl attribute contains an unsupported URL. You can only use https:// URLs.');
+    }
+  }
+}

--- a/generators/taskpane/templates/common/gulpfile.js
+++ b/generators/taskpane/templates/common/gulpfile.js
@@ -33,6 +33,8 @@ gulp.task('validate-xml', function () {
     schema: xsd
   });
   
+  validateHighResolutionIconUrl(xml, result);
+  
   if (resultsAsJson) {
     console.log(JSON.stringify(result));
   }
@@ -48,3 +50,16 @@ gulp.task('validate-xml', function () {
     }
   }
 });
+
+function validateHighResolutionIconUrl(xml, result) {
+  if (xml && result) {
+    if (xml.indexOf('<HighResolutionIconUrl ') > -1 &&
+      xml.indexOf('<HighResolutionIconUrl DefaultValue="https://') < 0) {
+        if (result.errors === null) {
+          result.errors = [];
+        }
+        
+        result.errors.push('The value of the HighResolutionIconUrl attribute contains an unsupported URL. You can only use https:// URLs.');
+    }
+  }
+}


### PR DESCRIPTION
Extended manifest validation with a check if the specified HighResolutionIconUrl is served via HTTPS solving issue #57.