### PR TITLE
pull request to add default root path '.'

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -26,6 +26,7 @@ module.exports = generators.Base.extend({
     this.option('root-path', {
       type: String,
       desc: 'Relative path where the project should be created (blank = current directory)',
+      default: '.',
       required: false
     });
 


### PR DESCRIPTION
Yo Office instructions does not work when you hit enter for the root path, we are missing default '.'