### PR TITLE
Issue 162

### DIFF
--- a/generators/content/templates/common/_package.json
+++ b/generators/content/templates/common/_package.json
@@ -10,12 +10,14 @@
     "gulp": "^3.9.0",
     "gulp-load-plugins": "^1.0.0",
     "gulp-minify-css": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-task-listing": "^1.0.1",
     "gulp-uglify": "^1.5.1",
     "gulp-webserver": "^0.9.1",
     "minimist": "^1.2.0",
     "run-sequence": "^1.1.5",
     "xml2js": "^0.4.15",
-    "xmllint": "git+https://github.com/kripken/xml.js.git"
+    "xmllint": "git+https://github.com/kripken/xml.js.git",
+    "yargs": "^4.6.0"
   }
 }

--- a/generators/content/templates/common/gulpfile.js
+++ b/generators/content/templates/common/gulpfile.js
@@ -1,6 +1,8 @@
 'use script';
 
 var gulp = require('gulp');
+var replace=require('gulp-replace');
+var argv = require('yargs').argv;
 var webserver = require('gulp-webserver');
 var fs = require('fs');
 var minimist = require('minimist');
@@ -12,7 +14,8 @@ var runSequence = require('run-sequence');
 var Xml2Js = require('xml2js');
 
 var config = {
-  release: './dist'
+  release: './dist',
+  localUrl:'https://localhost:8443/'
 };
 
 gulp.task('help', $.taskListing.withFilters(function (task) {
@@ -209,12 +212,26 @@ gulp.task('dist-minify-css', function() {
 });
 
 /**
+ * Replace local URL in manifest file if supplied via gulp dist --url
+ */
+gulp.task('replace-url', function(){
+    if(argv.url){
+        gulp.src([
+            config.release+'/manifest-*.xml'
+        ], { base: config.release+'/' })
+            .pipe(replace(config.localUrl, argv.url))
+            .pipe(gulp.dest(config.release));
+    }        
+});
+
+/**
  * Creates a release version of the project
  */
 gulp.task('dist', function () {
   runSequence(
     ['dist-remove'],
     ['dist-copy-files'],
+    ['replace-url'],
     ['dist-minify']
     );
 });

--- a/generators/content/templates/common/gulpfile.js
+++ b/generators/content/templates/common/gulpfile.js
@@ -212,7 +212,7 @@ gulp.task('dist-minify-css', function() {
 });
 
 /**
- * Replace local URL in manifest file if supplied via gulp dist --url
+ * Replace local URL in manifest file if supplied via gulp dist  --url
  */
 gulp.task('replace-url', function(){
     if(argv.url){

--- a/generators/mail/templates/common/_package.json
+++ b/generators/mail/templates/common/_package.json
@@ -10,12 +10,14 @@
     "gulp": "^3.9.0",
     "gulp-load-plugins": "^1.0.0",
     "gulp-minify-css": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-task-listing": "^1.0.1",
     "gulp-uglify": "^1.5.1",
     "gulp-webserver": "^0.9.1",
     "minimist": "^1.2.0",
     "run-sequence": "^1.1.5",
     "xml2js": "^0.4.15",
-    "xmllint": "git+https://github.com/kripken/xml.js.git"
+    "xmllint": "git+https://github.com/kripken/xml.js.git",
+    "yargs": "^4.6.0"
   }
 }

--- a/generators/mail/templates/common/gulpfile.js
+++ b/generators/mail/templates/common/gulpfile.js
@@ -1,6 +1,8 @@
 'use script';
 
 var gulp = require('gulp');
+var replace=require('gulp-replace');
+var argv = require('yargs').argv;
 var webserver = require('gulp-webserver');
 var fs = require('fs');
 var minimist = require('minimist');
@@ -12,7 +14,8 @@ var runSequence = require('run-sequence');
 var Xml2Js = require('xml2js');
 
 var config = {
-    release: './dist'
+    release: './dist',
+    localUrl:'https://localhost:8443/'
 };
 
 
@@ -231,12 +234,26 @@ gulp.task('dist-minify-css', function () {
 });
 
 /**
+ * Replace local URL in manifest file if supplied via gulp dist --url
+ */
+gulp.task('replace-url', function(){
+    if(argv.url){
+        gulp.src([
+            config.release+'/manifest-*.xml'
+        ], { base: config.release+'/' })
+            .pipe(replace(config.localUrl, argv.url))
+            .pipe(gulp.dest(config.release));
+    }        
+});
+
+/**
  * Creates a release version of the project
  */
 gulp.task('dist', function () {
     runSequence(
         ['dist-remove'],
         ['dist-copy-files'],
+        ['replace-url'],
         ['dist-minify']
         );
 });

--- a/generators/taskpane/templates/common/_package.json
+++ b/generators/taskpane/templates/common/_package.json
@@ -10,12 +10,14 @@
     "gulp": "^3.9.0",
     "gulp-load-plugins": "^1.0.0",
     "gulp-minify-css": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-task-listing": "^1.0.1",
     "gulp-uglify": "^1.5.1",
     "gulp-webserver": "^0.9.1",
     "minimist": "^1.2.0",
     "run-sequence": "^1.1.5",
     "xml2js": "^0.4.15",
-    "xmllint": "git+https://github.com/kripken/xml.js.git"
+    "xmllint": "git+https://github.com/kripken/xml.js.git",
+    "yargs": "^4.6.0"
   }
 }

--- a/generators/taskpane/templates/common/gulpfile.js
+++ b/generators/taskpane/templates/common/gulpfile.js
@@ -1,6 +1,8 @@
 'use script';
 
 var gulp = require('gulp');
+var replace=require('gulp-replace');
+var argv = require('yargs').argv;
 var webserver = require('gulp-webserver');
 var fs = require('fs');
 var minimist = require('minimist');
@@ -12,7 +14,8 @@ var runSequence = require('run-sequence');
 var Xml2Js = require('xml2js');
 
 var config = {
-  release: './dist'
+  release: './dist',
+  localUrl:'https://localhost:8443/'
 };
 
 gulp.task('help', $.taskListing.withFilters(function (task) {
@@ -207,6 +210,18 @@ gulp.task('dist-minify-css', function() {
     .pipe($.minifyCss())
     .pipe(gulp.dest(config.release));
 });
+/**
+ * Replace local URL in manifest file if supplied via gulp dist --url
+ */
+gulp.task('replace-url', function(){
+    if(argv.url){
+        gulp.src([
+            config.release+'/manifest-*.xml'
+        ], { base: config.release+'/' })
+            .pipe(replace(config.localUrl, argv.url))
+            .pipe(gulp.dest(config.release));
+    }        
+});
 
 /**
  * Creates a release version of the project
@@ -215,6 +230,7 @@ gulp.task('dist', function () {
   runSequence(
     ['dist-remove'],
     ['dist-copy-files'],
+    ['replace-url']
     ['dist-minify']
     );
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "Martella, Joe <martellaj@live.com>",
     "Mastykarz, Waldek <waldek@mastykarz.nl>",
     "Johnston, Jason <jasonjoh@microsoft.com>",
-    "Saxena, Arvind <arvindsa@exchange.microsoft.com>"
+    "Saxena, Arvind <arvindsa@exchange.microsoft.com>",
+    "Barron, Gavin",
+    "Costesich, Pablo Alejandro"
   ],
   "maintainers": [
     {


### PR DESCRIPTION
specify manifest base url in gulp build task using --url parameter
example
`gulp dist --url https://myaddin.azurewebsites.net/`
another task 'replace-url' will kick in reading parameter from process.args using yargs described here https://www.npmjs.com/package/yargs ,

if no url is passed original localhost baseurl will remain the same (localhost baseurl)