### PR TITLE
Add SupportUrl element to Mail addin manifest file

### DIFF
--- a/generators/mail/templates/common/manifest.xml
+++ b/generators/mail/templates/common/manifest.xml
@@ -7,6 +7,7 @@
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="<%= projectDisplayName %>" />
   <Description DefaultValue="[Outlook Add-in description]"/>
+  <SupportUrl DefaultValue="http://contoso.com/support" />
   <HighResolutionIconUrl DefaultValue="https://localhost:8443/images/hi-res-icon.png"/>
   <Hosts>
     <Host Name="Mailbox" />


### PR DESCRIPTION
This fix provides a default value similar to Description.  Maybe in the future, yo can ask for the support url and insert it as a value.

Fixes #175 