### PR TITLE
Fix duplicate key in webpack config

### DIFF
--- a/src/app/templates/ts/react/config/webpack.prod.js
+++ b/src/app/templates/ts/react/config/webpack.prod.js
@@ -18,7 +18,6 @@ module.exports = webpackMerge(commonConfig, {
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
             sourceMap: true,
-            compress: true,
             mangle: {
                 screw_ie8: true,
                 keep_fnames: true


### PR DESCRIPTION
Fix that `compress` key appears twice in
`webpack.optimize.UglifyJsPlugin` params.