### PR TITLE
PPT JQuery Path needs to be updated to not use RichAPI

### DIFF
--- a/src/app/templates/js/jquery/app.js
+++ b/src/app/templates/js/jquery/app.js
@@ -20,7 +20,18 @@
     /**
      * Insert your <%= host %> code here
      */
-    <% } else { %>
+    <% } else if (host === 'PowerPoint') { %><%# PowerPoint doesn't use RichAPI %>
+    /**
+     * Insert your <%= host %> code here
+     */
+    Office.context.document.setSelectedDataAsync('Hello World!', {
+        coercionType: Office.CoercionType.Text
+    }, result => {
+        if (result.status === Office.AsyncResultStatus.Failed) {
+            console.error(result.error.message);
+        }
+    });
+<% } else { %>
     return <%= host %>.run(function (context) {
       /**
        * Insert your <%= host %> code here


### PR DESCRIPTION
1. Run Yo Office -> PowerPoint -> NoTypeScript ->JQuery
  - The corresponding template should not use the react js
2. Use Cobly’s react-js checkin for guidance -- https://github.com/OfficeDev/generator-office/commit/92669c1eb062c94a9f58d32caf5286be99856c20 and make it so PPT doesn't use RichAPI

Validation:
- Did build of generator-office tool and then created add-in using PowerPoint JS JQuery template
- Having trouble actually adding the add-ins I created to PPT. I could use some guidance as to what I might be doing wrong.  I hit the following error successfully inserting a new add-in and clicking on "Show the Taskpane:  "Sorry we can't load the add-in.  Please make sure you have network and/or internet connectivity"
