### PR TITLE
Update outdated packages for generator office

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.104",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
-      "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
+      "version": "4.14.106",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.106.tgz",
+      "integrity": "sha512-tOSvCVrvSqFZ4A/qrqqm6p37GZoawsZtoR0SJhlF7EonNZUgrn8FfT+RNQ11h+NUpMt6QVe36033f3qEKBwfWA==",
       "dev": true
     },
     "@types/mocha": {
@@ -29,9 +29,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.55.tgz",
-      "integrity": "sha512-diCxfWNT4g2UM9Y+BPgy4s3egcZ2qOXc0mXLauvbsBUq9SBKQfh0SmuEUEhJVFZt/p6UDsjg1s2EgfM6OSlp4g==",
+      "version": "7.0.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.59.tgz",
+      "integrity": "sha512-FRRJ2hkgzySTgLnwQhXQCGkLRu1ImISVu/YKYWXCIbF6261nqXwDPQ+6xPzZw+c2Il2Zx2JfM/t0tCaw8wzbmA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -3097,9 +3097,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
       "dev": true
     },
     "untildify": {
@@ -3253,9 +3253,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yeoman-assert": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.0.tgz",
-      "integrity": "sha512-s5qwXatpdiqVJTwPj92jiE7f7RYKrbZsMZk2koic4hoQPbPwyQrGkaxGEvwal0Mf/dXkVpmfO3wVZCl7aU6uFQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.1.tgz",
+      "integrity": "sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ==",
       "dev": true
     },
     "yeoman-environment": {
@@ -3574,12 +3574,12 @@
       "dev": true
     },
     "yosay": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.1.tgz",
-      "integrity": "sha512-hN+Ft6X4Fq1uiguexEthlb6ba/RCx2DGF8fznsS166MDWbT7BzUxAJUOYnVMn+YdDE5VDMuRrkGFkUOdu5hvbA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
+      "integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
       "requires": {
         "ansi-regex": "2.1.1",
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "3.2.1",
         "chalk": "1.1.3",
         "cli-boxes": "1.0.0",
         "pad-component": "0.0.1",
@@ -3590,9 +3590,9 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^2.6.1",
     "uuid": "^3.0.1",
     "yeoman-generator": "^1.1.1",
-    "yosay": "^2.0.0",
+    "yosay": "^2.0.2",
     "opn": "^4.0.2"
   },
   "devDependencies": {
@@ -52,13 +52,13 @@
     "cpx": "^1.5.0",
     "mocha": "^3.2.0",
     "ts-node": "^3.0.2",
-    "typescript": "^2.2.2",
-    "yeoman-assert": "^3.0.0",
+    "typescript": "^2.8.1",
+    "yeoman-assert": "^3.1.1",
     "yeoman-test": "^1.6.0",
     "@types/applicationinsights": "^0.15.33",
     "@types/chalk": "^0.4.31",
-    "@types/lodash": "^4.14.59",
+    "@types/lodash": "^4.14.106",
     "@types/mocha": "^2.2.40",
-    "@types/node": "^7.0.12"
+    "@types/node": "^7.0.59"
   }
 }

--- a/src/app/templates/js/jquery/app.js
+++ b/src/app/templates/js/jquery/app.js
@@ -20,7 +20,18 @@
     /**
      * Insert your <%= host %> code here
      */
-    <% } else { %>
+    <% } else if (host === 'PowerPoint') { %><%# PowerPoint doesn't use RichAPI %>
+    /**
+     * Insert your <%= host %> code here
+     */
+    Office.context.document.setSelectedDataAsync('Hello World!', {
+        coercionType: Office.CoercionType.Text
+    }, result => {
+        if (result.status === Office.AsyncResultStatus.Failed) {
+            console.error(result.error.message);
+        }
+    });
+<% } else { %>
     return <%= host %>.run(function (context) {
       /**
        * Insert your <%= host %> code here

--- a/src/app/templates/js/jquery/app.js
+++ b/src/app/templates/js/jquery/app.js
@@ -20,18 +20,7 @@
     /**
      * Insert your <%= host %> code here
      */
-    <% } else if (host === 'PowerPoint') { %><%# PowerPoint doesn't use RichAPI %>
-    /**
-     * Insert your <%= host %> code here
-     */
-    Office.context.document.setSelectedDataAsync('Hello World!', {
-        coercionType: Office.CoercionType.Text
-    }, result => {
-        if (result.status === Office.AsyncResultStatus.Failed) {
-            console.error(result.error.message);
-        }
-    });
-<% } else { %>
+    <% } else { %>
     return <%= host %>.run(function (context) {
       /**
        * Insert your <%= host %> code here


### PR DESCRIPTION
Change to address https://github.com/OfficeDev/generator-office/issues/290

- Used npm-upgrade to upgrade package versions in generator office.
- Build project after running npm-upgrade
- Ran "npm outdated --dev" to ensure there are no more outdated versions