### PR TITLE
Update generator prompts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ The Microsoft Office client application that can host the add-in. The supported 
   - Optional
 
 #### `framework`
-Framework to use for the project. The supported arguments include JQuery (`jquery`), Angular (`angular`), and React (`react`). You can also use Manifest Only (`manifest-only`) which will create only the `manifest.xml` for an Office Add-in.
+Framework to use for the project. The supported arguments include JQuery (`jquery`), Angular (`angular`), and React (`react`). 
   - Type: String
   - Optional
 
@@ -75,6 +75,7 @@ After scaffolding the project, the generator (and all sub generators) run all pa
   - Optional
 
 #### `--js`
+>**Note:** Do not use this flag when you pass `react` as framework argument.
 
 Specifying `--js` tells the generator to use JavaScript.
 
@@ -88,7 +89,11 @@ Specifying `--js` tells the generator to use JavaScript.
   - Default: Add-in Name
   - Optional
 
->**Note:** Do not use this flag when you pass `react` as framework argument.
+  Specifying `--manifest-only` tells the generator to create only the `manifest.xml` for an Office Add-in
+
+  - Type: Boolean
+  - Default: False
+  - Optional
 
 ## Running the Generated Site
 

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ The Microsoft Office client application that can host the add-in. The supported 
   - Optional
 
 #### `framework`
-Framework to use for the project. The supported arguments include JQuery (`jquery`), Angular (`angular`), and React (`react`). 
+Framework to use for the project. The supported arguments include JQuery (`jquery`), Angular (`angular`), and React (`react`). You can also use Manifest Only (`manifest-only`) which will create only the `manifest.xml` for an Office Add-in.
   - Type: String
   - Optional
 
@@ -75,7 +75,6 @@ After scaffolding the project, the generator (and all sub generators) run all pa
   - Optional
 
 #### `--js`
->**Note:** Do not use this flag when you pass `react` as framework argument.
 
 Specifying `--js` tells the generator to use JavaScript.
 
@@ -83,16 +82,12 @@ Specifying `--js` tells the generator to use JavaScript.
   - Default: False
   - Optional
 
-  Specifying `--output` tells the generator to create a project folder that differs from the add-in name.
+>**Note:** Do not use this flag when you pass `react` as framework argument.
+
+Specifying `--output` tells the generator to create a project folder that differs from the add-in name.
 
   - Type: String
   - Default: Add-in Name
-  - Optional
-
-  Specifying `--manifest-only` tells the generator to create only the `manifest.xml` for an Office Add-in
-
-  - Type: Boolean
-  - Default: False
   - Optional
 
 ## Running the Generated Site
@@ -170,3 +165,4 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,18 @@ Specifying `--js` tells the generator to use JavaScript.
   - Default: False
   - Optional
 
+  Specifying `--output` tells the generator to create a project folder that differs from the add-in name.
+
+  - Type: String
+  - Default: Add-in Name
+  - Optional
+
+  Specifying `--show-webpage` tells the launch the generated resource webpage.
+
+  - Type: Boolean
+  - Default: False
+  - Optional
+
 >**Note:** Do not use this flag when you pass `react` as framework argument.
 
 ## Running the Generated Site

--- a/readme.md
+++ b/readme.md
@@ -88,12 +88,6 @@ Specifying `--js` tells the generator to use JavaScript.
   - Default: Add-in Name
   - Optional
 
-  Specifying `--show-webpage` tells the launch the generated resource webpage.
-
-  - Type: Boolean
-  - Default: False
-  - Optional
-
 >**Note:** Do not use this flag when you pass `react` as framework argument.
 
 ## Running the Generated Site

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -86,20 +86,6 @@ module.exports = yo.extend({
       let endForName = (new Date()).getTime();
       let durationForName = (endForName - startForName) / 1000;
 
-      /** begin prompting */
-      /** whether to create a new folder for the project */
-      let startForFolder = (new Date()).getTime();
-      let askForFolder = [{
-        name: 'folder',
-        message: 'Provide a name for the add-in project folder if you want it to be different than the add-in name?',
-        type: 'input',
-        default: answerForName.name || this.options.name,
-        when: this.options.name == null && this.options.output == null
-      }];
-      let answerForFolder = await this.prompt(askForFolder);
-      let endForFolder = (new Date()).getTime();
-      let durationForFolder = (endForFolder - startForFolder) / 1000;
-
       /** office client application that can host the addin */
       let startForHost = (new Date()).getTime();
       let askForHost = [{
@@ -141,7 +127,7 @@ module.exports = yo.extend({
        * Configure user input to have correct values
        */
       this.project = {
-        folder: this.options.name || answerForFolder.folder,
+        folder: this.options.name,
         name: this.options.name || answerForName.name,
         host: this.options.host || answerForHost.host,
         framework: this.options.framework || null,
@@ -233,7 +219,6 @@ module.exports = yo.extend({
       }
 
       /** appInsights logging */
-      insight.trackEvent('Folder', { CreatedSubFolder: this.project.folder.toString() }, { durationForFolder });
       insight.trackEvent('Name', { Name: this.project.name }, { durationForName });
       insight.trackEvent('Host', { Host: this.project.host }, { durationForHost });
       insight.trackEvent('IsManifestOnly', { IsManifestOnly: this.project.isManifestOnly.toString() }, { durationForManifestOnly });

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -51,12 +51,6 @@ module.exports = yo.extend({
       required: false,
       desc: 'Project folder name if different from project name'
     });
-
-    this.option('manifest-only', {
-      type: String,
-      required: false,
-      desc: 'Only create a manifest for the add-in'
-    });
   },
 
   /**
@@ -114,24 +108,21 @@ module.exports = yo.extend({
         name: this.options.name || answerForName.name,
         host: answerForHost.host || this.options.host,
         framework: this.options.framework || null,
-        isManifestOnly: this.options['manifest-only']
+        isManifestOnly: false
       };
 
+      // Set folder to specified name if 'output' option is passed as an argument
       if (this.options.output != null) {
         this.project.folder = this.options.output;
       }
-
-      // Set isManifestOnly flag to true if 'manifest-only' option is passed as an argument
-      let startForManifestOnly = (new Date()).getTime();
-      if (this.options['manifest-only'] != null ) {
+  
+      // Set isManifestOnly flag to true if framework argument is 'manifest-only'
+      if (this.options.framework === 'manifest-only') {
           this.project.isManifestOnly = true;
       }
-      let endForManifestOnly = (new Date()).getTime(); 
-      let durationForManifestOnly = (endForManifestOnly - startForManifestOnly) / 1000;
 
       // Set js flag to true if 'js' option is passed as an argument
-      let startForTs = (new Date()).getTime(); 
-      if (!(this.options.js == null)) {
+      if (this.options.js != null) {
         this.project.ts = !this.options.js;
       }
       else {
@@ -140,9 +131,6 @@ module.exports = yo.extend({
       if (this.options.framework === 'react') {
         this.project.ts = true;
       }
-      let endForTs = (new Date()).getTime(); 
-      let durationForTs = (endForTs - startForTs) / 1000; 
-
 
       /** technology used to create the addin (jquery / angular / etc) */
       let startForFramework = (new Date()).getTime();
@@ -181,14 +169,13 @@ module.exports = yo.extend({
       }
 
       /** appInsights logging */
+      const noElapsedTime = 0;
       insight.trackEvent('Name', { Name: this.project.name }, { durationForName });
-      insight.trackEvent('Host', { Host: this.project.host }, { durationForHost });
-      insight.trackEvent('IsManifestOnly', { IsManifestOnly: this.project.isManifestOnly.toString() }, { durationForManifestOnly });
-      
-      if (this.project.isManifestOnly === false) {
-        insight.trackEvent('IsTs', { IsTs: this.project.ts.toString() }, { durationForTs });
-        insight.trackEvent('Framework', { Framework: this.project.framework }, { durationForFramework });
-      }
+      insight.trackEvent('Folder', { CreatedSubFolder: this.project.folder.toString() }, { noElapsedTime }); 
+      insight.trackEvent('Host', { Host: this.project.host }, { durationForHost });    
+      insight.trackEvent('IsTs', { IsTs: this.project.ts.toString() }, { noElapsedTime });      
+      insight.trackEvent('IsManifestOnly', { IsManifestOnly: this.project.isManifestOnly.toString() }, { noElapsedTime });
+      insight.trackEvent('Framework', { Framework: this.project.framework }, { durationForFramework }); 
     } catch (err) {
       insight.trackException(new Error('Prompting Error: ' + err));
     }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -72,7 +72,7 @@ module.exports = yo.extend({
       let startForFolder = (new Date()).getTime();
       let askForFolder = [{
         name: 'folder',
-        message: 'Would you like to create a new subfolder for your project?',
+        message: 'Hello sucka, Would you like to create a new subfolder for your project?',
         type: 'confirm',
         default: false
       }];
@@ -154,15 +154,23 @@ module.exports = yo.extend({
       /** askForTs and askForFramework will only be triggered if it's not a manifest-only project */
       /** use TypeScript for the project */
       let startForTs = (new Date()).getTime();
-      let askForTs = [
-        {
-          name: 'ts',
-          type: 'confirm',
-          message: 'Would you like to use TypeScript?',
-          default: true,
-          when: (this.options.js == null) && (!this.project.isManifestOnly) && (this.options.framework !== 'react')
-        }
-      ];
+      let askForTs = [{
+        name: 'ts',
+        message: 'Which would you prefer to use?',
+        type: 'list',
+        default: true,
+        choices: [
+		              {
+		                name: 'Typescript',
+		                value: true
+		              },
+		              {
+		                name: 'Javascript',
+		                value: false
+		              }
+		              ],
+        when: (this.options.js == null) && (!this.project.isManifestOnly) && (this.options.framework !== 'react')
+      }];
       let answerForTs = await this.prompt(askForTs);
       let endForTs = (new Date()).getTime();
       let durationForTs = (endForTs - startForTs) / 1000;

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -167,7 +167,7 @@ module.exports = yo.extend({
 		                value: false
 		              }
 		              ],
-        when: (this.options.js == null) && (!this.project.isManifestOnly) && (this.options.framework !== 'react')
+        when: this.options.framework == null
       }];
       let answerForTs = await this.prompt(askForTs);
       let endForTs = (new Date()).getTime();
@@ -176,7 +176,7 @@ module.exports = yo.extend({
         this.project.ts = !this.options.js;
       }
       else {
-        this.project.ts = answerForTs.ts || false;
+        this.project.ts = answerForTs.ts || true;
       }
       if (this.options.framework === 'react') {
         this.project.ts = true;
@@ -261,7 +261,7 @@ module.exports = yo.extend({
         /** Show type of project creating in progress */
         if (this.project.framework !== 'manifest-only') {
           this.log('\n----------------------------------------------------------------------------------\n');
-          this.log(`      Creating ${chalk.bold.green(this.project.projectDisplayName)} add-in using ${chalk.bold.magenta(language)} and ${chalk.bold.cyan(this.project.framework)}\n`);
+          this.log(`      Creating ${chalk.bold.green(this.project.projectDisplayName)} add-in for ${chalk.bold.yellow(this.project.host)} using ${chalk.bold.magenta(language)} and ${chalk.bold.cyan(this.project.framework)}\n`);
           this.log('----------------------------------------------------------------------------------\n\n');
         }
         else {

--- a/src/test/manifest-only-project.ts
+++ b/src/test/manifest-only-project.ts
@@ -7,6 +7,27 @@ import * as helpers from 'yeoman-test';
 import * as assert from 'yeoman-assert';
 import * as path from 'path';
 
+const expectedFiles = [
+  'package.json',
+  'assets/icon-16.png',
+  'assets/icon-32.png',
+  'assets/icon-80.png',
+  'assets/logo-filled.png'
+]
+
+const unexpectedFiles = [
+  'function-file/function-file.html',
+  'function-file/function-file.js',
+  'function-file/function-file.html',
+  'function-file/function-file.ts',
+  'certs/ca.crt',
+  'certs/server.crt',
+  'certs/server.key',
+  'config/webpack.common.js',
+  'config/webpack.dev.js',
+  'config/webpack.prod.js'
+]
+
 /**
  * Test addin from user answers
  * manifest-only project, default folder, defaul host.
@@ -18,7 +39,6 @@ describe('manifest-only project - answers', () => {
     folder: false,
     name: projectDisplayName,
     host: 'excel',
-    isManifestOnly: true,
     ts: null,
     framework: null,
     open: false
@@ -28,20 +48,18 @@ describe('manifest-only project - answers', () => {
 	/** Test addin when user chooses jquery and typescript. */
   describe('manifest-only', () => {
     before((done) => {
-      helpers.run(path.join(__dirname, '../app')).withPrompts(answers).on('end', done);
+      helpers.run(path.join(__dirname, '../app')).withPrompts(answers).on('end', done)
+      .withOptions({ 'manifest-only': true })
     });
 
     it('creates expected files', (done) => {
       let expected = [
         manifestFileName,
-        'package.json',
-        'assets/icon-16.png',
-        'assets/icon-32.png',
-        'assets/icon-80.png',
-        'assets/logo-filled.png'
+        ...expectedFiles
       ];
 
       assert.file(expected);
+      assert.noFile(unexpectedFiles);
       done();
     });
   });
@@ -58,7 +76,6 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
     folder: null,
     name: null,
     host: null,
-    isManifestOnly: null,
     ts: null,
     framework: null,
     open: false
@@ -72,10 +89,10 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
   describe('argument: name', () => {
     before((done) => {
       answers.host = 'excel';
-      answers.isManifestOnly = true;
       argument[0] = projectEscapedName;
 
-      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withPrompts(answers).on('end', done);
+      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withPrompts(answers).on('end', done)
+      .withOptions({ 'manifest-only': true });
     });
 
     it('creates expected files', (done) => {
@@ -85,14 +102,11 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
 
       let expected = [
         manifestFileName,
-        'package.json',
-        'assets/icon-16.png',
-        'assets/icon-32.png',
-        'assets/icon-80.png',
-        'assets/logo-filled.png'
+        ...expectedFiles
       ];
 
       assert.file(expected);
+      assert.noFile(unexpectedFiles);
       done();
     });
   });
@@ -106,7 +120,8 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
       argument[0] = projectEscapedName;
       argument[1] = 'excel';
 
-      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withPrompts(answers).on('end', done);
+      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withPrompts(answers).on('end', done)
+      .withOptions({ 'manifest-only': true });
     });
 
     it('creates expected files', (done) => {
@@ -116,14 +131,11 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
 
       let expected = [
         manifestFileName,
-        'package.json',
-        'assets/icon-16.png',
-        'assets/icon-32.png',
-        'assets/icon-80.png',
-        'assets/logo-filled.png'
+        ...expectedFiles
       ];
 
       assert.file(expected);
+      assert.noFile(unexpectedFiles);
       done();
     });
   });
@@ -148,14 +160,11 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
 
       let expected = [
         manifestFileName,
-        'package.json',
-        'assets/icon-16.png',
-        'assets/icon-32.png',
-        'assets/icon-80.png',
-        'assets/logo-filled.png'
+        ...expectedFiles
       ];
 
       assert.file(expected);
+      assert.noFile(unexpectedFiles);
       done();
     });
   });

--- a/src/test/manifest-only-project.ts
+++ b/src/test/manifest-only-project.ts
@@ -40,7 +40,7 @@ describe('manifest-only project - answers', () => {
     name: projectDisplayName,
     host: 'excel',
     ts: null,
-    framework: null,
+    framework: 'manifest-only',
     open: false
   };
   let manifestFileName = projectEscapedName + '-manifest.xml';
@@ -49,7 +49,6 @@ describe('manifest-only project - answers', () => {
   describe('manifest-only', () => {
     before((done) => {
       helpers.run(path.join(__dirname, '../app')).withPrompts(answers).on('end', done)
-      .withOptions({ 'manifest-only': true })
     });
 
     it('creates expected files', (done) => {
@@ -77,7 +76,7 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
     name: null,
     host: null,
     ts: null,
-    framework: null,
+    framework: 'manifest-only',
     open: false
   };
   let argument = [];
@@ -92,7 +91,6 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
       argument[0] = projectEscapedName;
 
       helpers.run(path.join(__dirname, '../app')).withArguments(argument).withPrompts(answers).on('end', done)
-      .withOptions({ 'manifest-only': true });
     });
 
     it('creates expected files', (done) => {
@@ -121,7 +119,6 @@ describe('manifest-only project - answers & args - jquery & typescript', () => {
       argument[1] = 'excel';
 
       helpers.run(path.join(__dirname, '../app')).withArguments(argument).withPrompts(answers).on('end', done)
-      .withOptions({ 'manifest-only': true });
     });
 
     it('creates expected files', (done) => {

--- a/src/test/new-project.ts
+++ b/src/test/new-project.ts
@@ -338,47 +338,6 @@ describe('Create new project from prompts and command line overrides', () => {
       done();
     });
   });
-
-  	/**
-	 * Test addin when user pass in arguments
-	 * "my-office-add-in; excel; manifest-only"
-	 */
-  describe('arguments: name host', () => {
-    before((done) => {
-      argument[0] = projectEscapedName;
-      argument[1] = 'excel';
-      argument[2] = 'manifest-only';
-
-      helpers.run(path.join(__dirname, '../app'))
-        .withArguments(argument)
-        .withPrompts(answers)
-        .on('end', done);
-    });
-
-    it('creates expected files', (done) => {
-      let host = argument[1] ? argument[1] : answers.host;
-      let name = argument[0] ? argument[0] : answers.name;
-      let manifestFileName = name + '-manifest.xml';
-
-      let expected = [
-        manifestFileName,
-        ...expectedAssets,
-        'package.json',
-        'resource.html'
-      ];
-
-      let notExpected = [
-        expectedFunctionFilesJs,
-        expectedFunctionFilesTs,
-        certificateFiles,
-        configFiles
-      ]
-
-      assert.file(expected);
-      assert.noFile(notExpected);
-      done();
-    });
-  });
 });
 
 /**

--- a/src/test/new-project.ts
+++ b/src/test/new-project.ts
@@ -398,4 +398,42 @@ describe('Create new project from prompts with command line options', () => {
       done();
     });
   });
+
+  /** Test addin when user passes in --show-webpage. */
+  describe('options: --show-webpage', () => {
+    before((done) => {
+      helpers.run(path.join(__dirname, '../app'))
+        .withOptions({ 'show-webpage': true })
+        .withPrompts(answers)
+        .on('end', done);
+   });
+  });
+
+    /** Test addin when user passes in --output. */
+    let folderName = 'testFolder';
+    describe('options: --output', () => {
+      before((done) => {
+        answers.folder = true;
+        helpers.run(path.join(__dirname, '../app'))
+          .withOptions({ 'output': folderName })
+          .withPrompts(answers)
+          .on('end', done);
+      });
+  
+      it('creates expected files', (done) => {
+        let expected = [
+           manifestFileName,
+          ...expectedAssets,
+          ...expectedFunctionFilesTs,
+          ...commonExpectedFiles,
+          'app.css',
+          'tsconfig.json',
+          'src/index.ts',
+          'index.html',
+        ];  
+
+        assert.file(expected);
+        done();
+      });
+    });    
 });

--- a/src/test/new-project.ts
+++ b/src/test/new-project.ts
@@ -24,6 +24,18 @@ const expectedFunctionFilesTs = [
   'function-file/function-file.ts',
 ];
 
+const certificateFiles = [
+  'certs/ca.crt',
+  'certs/server.crt',
+  'certs/server.key'
+]
+
+const configFiles = [
+  'config/webpack.common.js',
+  'config/webpack.dev.js',
+  'config/webpack.prod.js'
+]
+
 const commonExpectedFiles = [
   '.gitignore',
   'package.json',
@@ -287,7 +299,7 @@ describe('Create new project from prompts and command line overrides', () => {
       assert.file(expected);
       done();
     });
-  });
+  });  
 
 	/**
 	 * Test addin when user pass in argument
@@ -322,6 +334,47 @@ describe('Create new project from prompts and command line overrides', () => {
       ];
 
       assert.file(expected);
+      done();
+    });
+  });
+
+  	/**
+	 * Test addin when user pass in arguments
+	 * "my-office-add-in; excel; manifest-only"
+	 */
+  describe('arguments: name host', () => {
+    before((done) => {
+      argument[0] = projectEscapedName;
+      argument[1] = 'excel';
+      argument[2] = 'manifest-only';
+
+      helpers.run(path.join(__dirname, '../app'))
+        .withArguments(argument)
+        .withPrompts(answers)
+        .on('end', done);
+    });
+
+    it('creates expected files', (done) => {
+      let host = argument[1] ? argument[1] : answers.host;
+      let name = argument[0] ? argument[0] : answers.name;
+      let manifestFileName = name + '-manifest.xml';
+
+      let expected = [
+        manifestFileName,
+        ...expectedAssets,
+        'package.json',
+        'resource.html'
+      ];
+
+      let notExpected = [
+        expectedFunctionFilesJs,
+        expectedFunctionFilesTs,
+        certificateFiles,
+        configFiles
+      ]
+
+      assert.file(expected);
+      assert.noFile(notExpected);
       done();
     });
   });
@@ -397,17 +450,7 @@ describe('Create new project from prompts with command line options', () => {
       assert.file(expected);
       done();
     });
-  });
-
-  /** Test addin when user passes in --show-webpage. */
-  describe('options: --show-webpage', () => {
-    before((done) => {
-      helpers.run(path.join(__dirname, '../app'))
-        .withOptions({ 'show-webpage': true })
-        .withPrompts(answers)
-        .on('end', done);
-   });
-  });
+  }); 
 
     /** Test addin when user passes in --output. */
     let folderName = 'testFolder';
@@ -432,6 +475,11 @@ describe('Create new project from prompts with command line options', () => {
           'index.html',
         ];  
 
+        // Ensure manifest is found in expected output folder
+        assert.ok(path.win32.resolve(manifestFileName).toString().indexOf(folderName) >=0,
+        'manifest file not found in specified output folder');
+
+        // Verify expected files were created
         assert.file(expected);
         done();
       });

--- a/src/test/new-project.ts
+++ b/src/test/new-project.ts
@@ -91,9 +91,9 @@ describe('Create new project from prompts only', () => {
   /** Test addin when user chooses jquery and javascript. */
   describe('jquery & javascript', () => {
     before((done) => {
-      answers.ts = false;
       answers.framework = 'jquery';
       helpers.run(path.join(__dirname, '../app'))
+        .withOptions({ js: true })
         .withPrompts(answers)
         .on('end', done);
     });
@@ -148,6 +148,7 @@ describe('Create new project from prompts only', () => {
       answers.ts = false;
       answers.framework = 'angular';
       helpers.run(path.join(__dirname, '../app'))
+        .withOptions({ js: true })
         .withPrompts(answers)
         .on('end', done);
     });


### PR DESCRIPTION
- Added new output param to specify folder if user wants it to be different than add-in name
- Removed prompt to specify folder name. Will default to add-in name for folder name.  If the user wishes to specify a different name they can use the output param
-Updated Typescript prompt so it now shows Typescript and JavaScript. This makes it clearer to the user what they are selecting if they don't select Typescript
- removed logic to show resource.html
- Changed logic so that we always call _postInstallHints at the end of yo office. ._postInstallHints mentions that a resource.html was created and provides other post-install info
- Added two new tests to new-project.ts
- Updated readme.md with new output param