### PR TITLE
Updated Travis to build and run tests on Mac as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ node_js:
   - '6.9.1'
 before_script: "npm run build"
 script: "npm run test"
+os:
+  - linux
+  - osx


### PR DESCRIPTION
- Updated .travis.yml so we run builds on Mac, as well as Linux (this is something Adam and I discussed as an addition that would be good to have)
- I have been in contact directly with folks from Travis CI and they told me adding the 'os' param with Linux and OsX is the way to ensure we retain our current build/test environment while adding on Mac as well