### PR TITLE
-Update webpack.config.js so that the source map files are built when…

### DIFF
--- a/src/app/templates/ts/base/webpack.config.js
+++ b/src/app/templates/ts/base/webpack.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
+    devtool: 'source-map',
     entry: {
         app: './src/index.ts',
         'function-file': './function-file/function-file.ts'


### PR DESCRIPTION
… running 'npm run build' for typescript projects

- Exercised scenario cited in https://office.visualstudio.com/DefaultCollection/OC/Excel/_workitems/edit/2088313 to ensure we now work as expected and that we can now set a breakpoint in index.ts and that we hit that breakpoint when running code for the add-in
- I was able to confirm this fix for Jquery nd Angular typescript projects, but it seems like we have a general problem with React projects seemingly related to the specialized webpack config files that we copy over for React.  When we run 'npm run build' for React projects, we end up generating very wonky names for the js and source-map files.  I think this may contribute to the fact that when I try to debug React project in VS2017, I am unable to see the .ts file at all. I opened https://github.com/OfficeDev/generator-office/issues/330 to track this issue with React typescript projects