### PR TITLE
Adding missing colon

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -121,7 +121,7 @@ module.exports = yo.extend({
         {
           name: 'scriptType',
           type: 'list',
-          message: 'Choose a script type',
+          message: 'Choose a script type:',
           choices: [typescript, javascript],
           default: typescript,
           when: this.options.js == null  && this.options.ts == null


### PR DESCRIPTION
Making the "Choose a project type:" and "Choose a script type:" prompts have the same punctuation format.