### PR TITLE
I created two branches off of the Excel Custom Functions repo:

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -4,54 +4,50 @@
             "displayname": "Office Add-in project using Angular framework",
             "templates": {
                 "typescript": {
-                     "repository": "",
-                    "branch": "master"},
+                    "repository": ""},
                 "javascript": {
-                    "repository": "",
-                    "branch": "master"}
-                }       
-        },
-        "excel-functions": {
-            "displayname": "Excel Custom Functions Add-in project (May 2018 Preview: Requires the Insider channel for Excel)",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
-                    "branch": "Preview_May_2018"}
-                }
+                    "repository": ""}
+                }        
         },
         "excel-functions-preview-refresh": {
             "displayname": "Excel Custom Functions Add-in project (September 2018 Preview Refresh: Requires the Insider channel for Excel)",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
-                    "branch": "Preview_Refresh_Sept_2018"}
+                    "branches": [
+                        {"name": "Preview_Refresh_Sept_2018"}]}
+                }
+        },
+        "excel-functions": {
+            "displayname": "Excel Custom Functions Add-in project (May 2018 Preview: Requires the Insider channel for Excel)",
+            "templates": {
+                "javascript": {
+                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
+                    "branches": [
+                        {"name": "Preview_May_2018"}]}
                 }
         },
         "jquery": {
             "displayname": "Office Add-in project using Jquery framework",
             "templates": {
                 "typescript": {
-                     "repository": "",
-                    "branch": "master"},
+                    "repository": ""},
                 "javascript": {
-                    "repository": "",
-                    "branch": "master"}
-                }  
+                    "repository": ""}
+                }
         },
         "manifest": {
             "displayname": "Office Add-in containing the manifest only",
             "templates": {
                 "manifestonly": {
-                    "repository": "",
-                    "branch": "master"}
+                    "repository": ""}
                 }
         },
         "react": {
             "displayname": "Office Add-in project using React framework",
             "templates": {
                 "typescript": {
-                    "repository": "",
-                    "branch": "master"}
+                    "repository": ""}
                 }
             }
         },
@@ -79,4 +75,3 @@
             "repository": ""}
         }
  }
-

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -4,39 +4,54 @@
             "displayname": "Office Add-in project using Angular framework",
             "templates": {
                 "typescript": {
-                    "repository": ""},
+                     "repository": "",
+                    "branch": "master"},
                 "javascript": {
-                    "repository": ""}
-                }        
+                    "repository": "",
+                    "branch": "master"}
+                }       
         },
         "excel-functions": {
-            "displayname": "Excel Custom Functions Add-in project (Preview: Requires the Insider channel for Excel)",
+            "displayname": "Excel Custom Functions Add-in project (May 2018 Preview: Requires the Insider channel for Excel)",
             "templates": {
                 "javascript": {
-                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions"}
+                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
+                    "branch": "Preview_May_2018"}
+                }
+        },
+        "excel-functions-preview-refresh": {
+            "displayname": "Excel Custom Functions Add-in project (September 2018 Preview Refresh: Requires the Insider channel for Excel)",
+            "templates": {
+                "javascript": {
+                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
+                    "branch": "Preview_Refresh_Sept_2018"}
                 }
         },
         "jquery": {
             "displayname": "Office Add-in project using Jquery framework",
             "templates": {
                 "typescript": {
-                    "repository": ""},
+                     "repository": "",
+                    "branch": "master"},
                 "javascript": {
-                    "repository": ""}
-                }
+                    "repository": "",
+                    "branch": "master"}
+                }  
         },
         "manifest": {
             "displayname": "Office Add-in containing the manifest only",
             "templates": {
                 "manifestonly": {
-                    "repository": ""}
+                    "repository": "",
+                    "branch": "master"}
                 }
         },
         "react": {
             "displayname": "Office Add-in project using React framework",
             "templates": {
                 "typescript": {
-                    "repository": ""}
+                    "repository": "",
+                    "branch": "master"}
                 }
             }
         },

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -94,7 +94,7 @@ export default class projectsJsonData{
       return undefined;
     }
 
-    getProjectTemplateBranch(projectTypeKey: string, scriptType: string)
+    getProjectTemplateBranchName(projectTypeKey: string, scriptType: string, branchIndex: number)
     {
       // Check to see if repository is defined. If not, then a branch won't be defined, so just return.
       if (this.getProjectTemplateRepository(projectTypeKey, scriptType) == ""){
@@ -110,7 +110,7 @@ export default class projectsJsonData{
               return undefined;
             }
             else{
-              return this.m_projectJsonData.manifest.templates.manifestonly.branches[0];
+              return this.m_projectJsonData.manifest.templates.manifestonly.branches[branchIndex].name;
             }
           }
           else{
@@ -118,7 +118,7 @@ export default class projectsJsonData{
               return undefined;
             }
             else{
-              return this.m_projectJsonData.projectTypes[key].templates[scriptType].branches[0];
+              return this.m_projectJsonData.projectTypes[key].templates[scriptType].branches[branchIndex].name;
             }
           }          
         }

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -93,4 +93,20 @@ export default class projectsJsonData{
       }
       return undefined;
     }
+
+    getProjectTemplateBranch(projectTypeKey: string, scriptType: string)
+    {
+      for (let key in this.m_projectJsonData.projectTypes)
+      {
+        if (_.toLower(projectTypeKey) == key){
+          if (projectTypeKey == 'manifest'){
+           return this.m_projectJsonData.projectTypes[key].templates.manifestonly.branch;
+          }
+          else{
+            return this.m_projectJsonData.projectTypes[key].templates[scriptType].branch;
+          }          
+        }
+      }
+      return undefined;
+    }
   }

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -84,7 +84,7 @@ export default class projectsJsonData{
       {
         if (_.toLower(projectTypeKey) == key){
           if (projectTypeKey == 'manifest'){
-           return this.m_projectJsonData.projectTypes[key].templates.manifestonly.repository;
+           return this.m_projectJsonData.manifest.templates.manifestonly.repository;
           }
           else{
             return this.m_projectJsonData.projectTypes[key].templates[scriptType].repository;
@@ -96,14 +96,30 @@ export default class projectsJsonData{
 
     getProjectTemplateBranch(projectTypeKey: string, scriptType: string)
     {
+      // Check to see if repository is defined. If not, then a branch won't be defined, so just return.
+      if (this.getProjectTemplateRepository(projectTypeKey, scriptType) == ""){
+        return undefined;
+      }
+
       for (let key in this.m_projectJsonData.projectTypes)
       {
         if (_.toLower(projectTypeKey) == key){
-          if (projectTypeKey == 'manifest'){
-           return this.m_projectJsonData.projectTypes[key].templates.manifestonly.branch;
+          if (projectTypeKey == 'manifest')
+          {
+            if (this.m_projectJsonData.manifest.templates.manifestonly.branches == undefined){
+              return undefined;
+            }
+            else{
+              return this.m_projectJsonData.manifest.templates.manifestonly.branches[0];
+            }
           }
           else{
-            return this.m_projectJsonData.projectTypes[key].templates[scriptType].branch;
+            if (this.m_projectJsonData.projectTypes[key].templates[scriptType].branches == undefined){
+              return undefined;
+            }
+            else{
+              return this.m_projectJsonData.projectTypes[key].templates[scriptType].branches[0];
+            }
           }          
         }
       }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -265,7 +265,7 @@ module.exports = yo.extend({
         if (projectRepo != "")
         {
           let projectBranch = jsonData.getProjectTemplateBranch(this.project.projectType, language == 'ts' ? _.toLower(typescript) : _.toLower(javascript));
-          git().clone(projectRepo, this.destinationPath(), ['--branch', projectBranch]);
+          git().clone(projectRepo, this.destinationPath(), ['--branch', projectBranch == undefined ? 'master' : projectBranch.name]);
         }
         else
         {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -264,8 +264,8 @@ module.exports = yo.extend({
         let projectRepo = jsonData.getProjectTemplateRepository(this.project.projectType, language == 'ts' ? _.toLower(typescript) : _.toLower(javascript));
         if (projectRepo != "")
         {
-          let projectBranch = jsonData.getProjectTemplateBranch(this.project.projectType, language == 'ts' ? _.toLower(typescript) : _.toLower(javascript));
-          git().clone(projectRepo, this.destinationPath(), ['--branch', projectBranch == undefined ? 'master' : projectBranch.name]);
+          let projectBranchName = jsonData.getProjectTemplateBranchName(this.project.projectType, language == 'ts' ? _.toLower(typescript) : _.toLower(javascript), 0 /* branchIndex */);
+          git().clone(projectRepo, this.destinationPath(), ['--branch', projectBranchName == undefined ? 'master' : projectBranchName]);
         }
         else
         {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -15,6 +15,7 @@ import projectsJsonData from './config/projectsJsonData';
 let insight = appInsights.getClient('1ced6a2f-b3b2-4da5-a1b8-746512fbc840');
 let git = require("simple-git");
 const excelCustomFunctions = `excel-functions`;
+const excelCustomFunctionsPreviewRefresh = "excel-functions-preview-refresh";
 const manifest = 'manifest';
 const typescript = `Typescript`;
 const javascript = `Javascript`;
@@ -112,7 +113,7 @@ module.exports = yo.extend({
           isManifestProject = true; }
 
       /* Set isExcelFunctionsProject to true if ExcelexcelFunctions project type selected from prompt or ExcelexcelFunctions was specified via the command prompt */
-      if ((answerForProjectType.projectType != null  && answerForProjectType.projectType) == excelCustomFunctions
+      if ((answerForProjectType.projectType != null  && (answerForProjectType.projectType) == excelCustomFunctions || answerForProjectType.projectType == excelCustomFunctionsPreviewRefresh)
       || (this.options.projectType != null && _.toLower(this.options.projectType) == excelCustomFunctions)) { 
         isExcelFunctionsProject = true; }
 
@@ -263,7 +264,8 @@ module.exports = yo.extend({
         let projectRepo = jsonData.getProjectTemplateRepository(this.project.projectType, language == 'ts' ? _.toLower(typescript) : _.toLower(javascript));
         if (projectRepo != "")
         {
-          git().clone(projectRepo, this.destinationPath());
+          let projectBranch = jsonData.getProjectTemplateBranch(this.project.projectType, language == 'ts' ? _.toLower(typescript) : _.toLower(javascript));
+          git().clone(projectRepo, this.destinationPath(), ['--branch', projectBranch]);
         }
         else
         {


### PR DESCRIPTION
Preview May 2018  this contains the current custom functions template and matches whats in master
Preview_Refresh_Sept_2018  this contains the custom functions with the updated CDN, as well as the replacement of OfficeExtension.Promise with just Promise for the async function example

I have made the updates in Yo Office so that we now show the following options:
  Office Add-in project using Angular framework
  Excel Custom Functions Add-in project (May 2018 Preview: Requires the Insider channel for Excel)
  Excel Custom Functions Add-in project (September 2018 Preview Refresh: Requires the Insider channel for Excel)
  Office Add-in project using Jquery framework
  Office Add-in containing the manifest only
  Office Add-in project using React framework

We will pull the template from the correct custom functions branch depending on which option the user chooses.  I will be sending out that PR is  a few.

We can make any additional changes to the Preview_Refresh_Sept_2018 branch independent from Yo Office, which is of course ideal and a major reason why we made this first initial move to having separate repos for each project template.