### PR TITLE
Temportary fix for issue causing Yo Office to end prematurely on Node…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - node_modules
 node_js:
   - 'stable'
+  - '8.12.0'
 before_script: "npm run build"
 script: "npm run test"
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   - node_modules
 node_js:
   - 'stable'
-  - '8.12.0'
 before_script: "npm run build"
 script: "npm run test"
 os:

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -118,8 +118,8 @@ module.exports = yo.extend({
 
       // Determine if we should prompt for script type. This is to address a bug that is causing Yo Office to crash in Node v10.10.0 - Issue #354
       // This is a temportary fix - we need to clean up the code in the next major version of the generator
-      let promptForScriptType = !isManifestProject && this.options.js == null  && this.options.ts == null && (this.options.projectType != null && jsonData.projectBothScriptTypes(this.options.projectType)
-      || answerForProjectType.projectType != null && jsonData.projectBothScriptTypes(answerForProjectType.projectType))
+      let promptForScriptType = !isManifestProject && this.options.js === null  && this.options.ts === null && (this.options.projectType !== null && jsonData.projectBothScriptTypes(this.options.projectType)
+      || answerForProjectType.projectType !== null && jsonData.projectBothScriptTypes(answerForProjectType.projectType))
       
       let answerForScriptType;
       let askForScriptType = [
@@ -216,7 +216,7 @@ module.exports = yo.extend({
         projectType: _.toLower(this.options.projectType) || _.toLower(answerForProjectType.projectType),
         isManifestOnly: isManifestProject,
         isExcelFunctionsProject: isExcelFunctionsProject,
-        scriptType: answerForScriptType != undefined ? answerForScriptType.scriptType : undefined
+        scriptType: (answerForScriptType !== undefined) ? answerForScriptType.scriptType : undefined
       };
 
       if (this.options.js || this.project.projectType === excelCustomFunctions) {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -116,8 +116,12 @@ module.exports = yo.extend({
       || (this.options.projectType != null && _.toLower(this.options.projectType) == excelCustomFunctions)) { 
         isExcelFunctionsProject = true; }
 
-      /* askForTs and askForProjectType will only be triggered if the js param is null, it's not a Manifest project,
-       * it's not an ExcelexcelFunctions project and the project type exists for both script types */      
+      // Determine if we should prompt for script type. This is to address a bug that is causing Yo Office to crash in Node v10.10.0 - Issue #354
+      // This is a temportary fix - we need to clean up the code in the next major version of the generator
+      let promptForScriptType = !isManifestProject && this.options.js == null  && this.options.ts == null && (this.options.projectType != null && jsonData.projectBothScriptTypes(this.options.projectType)
+      || answerForProjectType.projectType != null && jsonData.projectBothScriptTypes(answerForProjectType.projectType))
+      
+      let answerForScriptType;
       let askForScriptType = [
         {
           name: 'scriptType',
@@ -125,12 +129,11 @@ module.exports = yo.extend({
           message: 'Choose a script type',
           choices: [typescript, javascript],
           default: typescript,
-          when: this.options.js == null  && this.options.ts == null
-          && (this.options.projectType != null && jsonData.projectBothScriptTypes(this.options.projectType)
-          || answerForProjectType.projectType != null && jsonData.projectBothScriptTypes(answerForProjectType.projectType))
         }
       ];
-      let answerForScriptType = await this.prompt(askForScriptType);
+      if (promptForScriptType){
+        answerForScriptType = await this.prompt(askForScriptType);
+      }
 
       /* askforName will be triggered if no project name was specified via command line Name argument */
       let startForName = (new Date()).getTime();
@@ -213,7 +216,7 @@ module.exports = yo.extend({
         projectType: _.toLower(this.options.projectType) || _.toLower(answerForProjectType.projectType),
         isManifestOnly: isManifestProject,
         isExcelFunctionsProject: isExcelFunctionsProject,
-        scriptType: answerForScriptType.scriptType
+        scriptType: answerForScriptType != undefined ? answerForScriptType.scriptType : undefined
       };
 
       if (this.options.js || this.project.projectType === excelCustomFunctions) {


### PR DESCRIPTION
… v10.10.0 (see https://github.com/OfficeDev/generator-office/issues/354)

- Still not sure why we bail out of Yo Office on Node 10.10.0 and don't on earlier versions of Node after we do the check for the script types available for the specified project type. For now, will just bypass the prompt for script type if promptForScriptType is false
- Also updated .travis.yml so we test on stable Node build as well as an earlier build

I think we should get this fix out ASAP because more people are starting to run into this