### PR TITLE
Use office-toolbox to validate for all templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ As you modify your `manifest.xml` file, use the included [Office Add-in Validato
 
 To run Office Add-in Validator, use the following command in your project directory:
 ```bash
-$ npm run validate your_manifest.xml
+$ npm run validate
 ```
 ![](src/docs/assets/validator.gif)
 

--- a/src/app/templates/js/angular/package.json
+++ b/src/app/templates/js/angular/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@angular/common": "^5.2.9",
@@ -31,7 +31,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "webpack": "^4.1.1",
     "webpack-cli": "^2.0.12",
     "webpack-dev-server": "^3.1.1"

--- a/src/app/templates/js/angular/package.json
+++ b/src/app/templates/js/angular/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@angular/common": "^5.2.9",

--- a/src/app/templates/js/jquery/package.json
+++ b/src/app/templates/js/jquery/package.json
@@ -24,7 +24,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "webpack": "^4.1.1",
     "webpack-cli": "^2.0.12",
     "webpack-dev-server": "^3.1.1"

--- a/src/app/templates/js/jquery/package.json
+++ b/src/app/templates/js/jquery/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/js/jquery/package.json
+++ b/src/app/templates/js/jquery/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/manifest-only/package.json
+++ b/src/app/templates/manifest-only/package.json
@@ -4,7 +4,7 @@
   "author": "",
   "version": "0.1.0",
   "scripts": {
-    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "office-toolbox": "^0.1.0"

--- a/src/app/templates/manifest-only/package.json
+++ b/src/app/templates/manifest-only/package.json
@@ -4,7 +4,7 @@
   "author": "",
   "version": "0.1.0",
   "scripts": {
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "office-addin-validator": "^1.0.1"

--- a/src/app/templates/manifest-only/package.json
+++ b/src/app/templates/manifest-only/package.json
@@ -7,7 +7,7 @@
     "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
-    "office-addin-validator": "^1.0.1"
+    "office-toolbox": "^0.1.0"
   },
   "devDependencies": {}
 }

--- a/src/app/templates/ts/angular/package.json
+++ b/src/app/templates/ts/angular/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "office-toolbox": "^0.1.0",

--- a/src/app/templates/ts/angular/package.json
+++ b/src/app/templates/ts/angular/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "office-toolbox": "^0.1.0",

--- a/src/app/templates/ts/angular/package.json
+++ b/src/app/templates/ts/angular/package.json
@@ -33,7 +33,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "ts-loader": "^4.1.0",
     "webpack": "^4.1.1",
     "webpack-cli": "^2.0.12",

--- a/src/app/templates/ts/jquery/package.json
+++ b/src/app/templates/ts/jquery/package.json
@@ -22,7 +22,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "ts-loader": "^4.1.0",
     "webpack": "^4.1.1",
     "webpack-cli": "^2.0.12",

--- a/src/app/templates/ts/jquery/package.json
+++ b/src/app/templates/ts/jquery/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/ts/jquery/package.json
+++ b/src/app/templates/ts/jquery/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -9,7 +9,7 @@
         "start": "webpack-dev-server --inline --config config/webpack.dev.js --progress",
         "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
         "build": "npm run clean && webpack --config config/webpack.prod.js --colors --progress --bail",
-        "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
+        "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
     },
     "dependencies": {
         "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -9,7 +9,7 @@
         "start": "webpack-dev-server --inline --config config/webpack.dev.js --progress",
         "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
         "build": "npm run clean && webpack --config config/webpack.prod.js --colors --progress --bail",
-        "validate": "./node_modules/.bin/validate-office-addin"
+        "validate": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml"
     },
     "dependencies": {
         "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -34,7 +34,6 @@
         "html-webpack-plugin": "2.28.0",
         "less": "^3.0.1",
         "less-loader": "^4.0.5",
-        "office-addin-validator": "^1.0.1",
         "postcss-loader": "1.3.3",
         "react-hot-loader": "^3.1.3",
         "rimraf": "2.6.1",


### PR DESCRIPTION
As described in #359 the generator creates different results depending on user's selection for hosting application and project type. Instead of having two top-level dependencies for `office-toolbox` and `office-addin-validator`, validation should be done by `office-toolbox` for all templates. 
