### PR TITLE
fix(generate): write files in async task - fixes #363

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -186,7 +186,7 @@ module.exports = yo.extend({
     .then(() => {
       done();
     })
-    .catch((err)=>{
+    .catch((err) => {
       insight.trackException(new Error('Installation Error: ' + err));
       process.exitCode = 1;
     });
@@ -279,7 +279,7 @@ module.exports = yo.extend({
             if (fs.existsSync(gitFolder)){
               helperMethods.deleteFolderRecursively(gitFolder);
             }
-            return err? reject(err): resolve();
+            return err ? reject(err) : resolve();
           });
         }
         else


### PR DESCRIPTION
When templates come from an external repo, git.clone is used to pull the template. This method is async, so the generator has to wait until cloning actually finished

