### PR TITLE
fix(scripts): use office-toolbox for validation

### DIFF
--- a/src/app/templates/js/angular/package.json
+++ b/src/app/templates/js/angular/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@angular/common": "^5.2.9",
@@ -31,7 +31,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "webpack": "^4.1.1",
     "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.1"

--- a/src/app/templates/js/jquery/package.json
+++ b/src/app/templates/js/jquery/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",
@@ -24,7 +24,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "webpack": "^4.1.1",
     "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.1"

--- a/src/app/templates/manifest-only/package.json
+++ b/src/app/templates/manifest-only/package.json
@@ -4,10 +4,10 @@
   "author": "",
   "version": "0.1.0",
   "scripts": {
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
-    "office-addin-validator": "^1.0.1"
+    "office-toolbox": "^0.1.0"
   },
   "devDependencies": {}
 }

--- a/src/app/templates/ts/angular/package.json
+++ b/src/app/templates/ts/angular/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "office-toolbox": "^0.1.0",
@@ -33,7 +33,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "ts-loader": "^4.1.0",
     "webpack": "^4.1.1",
     "webpack-cli": "^3.1.1",

--- a/src/app/templates/ts/jquery/package.json
+++ b/src/app/templates/ts/jquery/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
     "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "./node_modules/.bin/validate-office-addin"
+    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",
@@ -22,7 +22,6 @@
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.7",
-    "office-addin-validator": "^1.0.1",
     "ts-loader": "^4.1.0",
     "webpack": "^4.1.1",
     "webpack-cli": "^3.1.1",

--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -9,7 +9,7 @@
         "start": "webpack-dev-server --inline --config config/webpack.dev.js --progress",
         "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
         "build": "npm run clean && webpack --config config/webpack.prod.js --colors --progress --bail",
-        "validate": "./node_modules/.bin/validate-office-addin"
+        "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
     },
     "dependencies": {
         "@microsoft/office-js-helpers": "^1.0.1",
@@ -34,7 +34,6 @@
         "html-webpack-plugin": "2.28.0",
         "less": "^3.0.1",
         "less-loader": "^4.0.5",
-        "office-addin-validator": "^1.0.1",
         "postcss-loader": "1.3.3",
         "react-hot-loader": "^3.1.3",
         "rimraf": "2.6.1",


### PR DESCRIPTION
Instead of using internal node_module `office-addin-validator` directly, the `office-toolbox validate` command will be used in all possible templates. fixes #359