### PR TITLE
fix: remove projectInternalName prefix from manifest

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -31,8 +31,8 @@ module.exports = yo.extend({
   constructor: function () {
     yo.apply(this, arguments);
 
-    this.argument('projectType', { type: String, required: false }); 
-    this.argument('name', { type: String, required: false }); 
+    this.argument('projectType', { type: String, required: false });
+    this.argument('name', { type: String, required: false });
     this.argument('host', { type: String, required: false });
 
     this.option('skip-install', {
@@ -75,13 +75,13 @@ module.exports = yo.extend({
     }
     let message = `Welcome to the ${chalk.bold.green('Office Add-in')} generator, by ${chalk.bold.green('@OfficeDev')}! Let\'s create a project together!`;
     this.log(yosay(message));
-    this.project = {};    
+    this.project = {};
   },
 
   /* Prompt user for project options */
   prompting: async function () {
     try {
-      let jsonData = new projectsJsonData(this.templatePath()); 
+      let jsonData = new projectsJsonData(this.templatePath());
       let isManifestProject = false;
       let isExcelFunctionsProject = false;
 
@@ -106,22 +106,22 @@ module.exports = yo.extend({
       let answerForProjectType = await this.prompt(askForProjectType);
       let endForProjectType = (new Date()).getTime();
       let durationForProjectType = (endForProjectType - startForProjectType) / 1000;
-      
+
       /* Set isManifestProject to true if Manifest project type selected from prompt or Manifest was specified via the command prompt */
       if ((answerForProjectType.projectType != null && _.toLower(answerForProjectType.projectType) == manifest)
-      || (this.options.projectType != null && _.toLower(this.options.projectType)) == manifest) { 
+      || (this.options.projectType != null && _.toLower(this.options.projectType)) == manifest) {
           isManifestProject = true; }
 
       /* Set isExcelFunctionsProject to true if ExcelexcelFunctions project type selected from prompt or ExcelexcelFunctions was specified via the command prompt */
       if ((answerForProjectType.projectType != null  && answerForProjectType.projectType) == excelCustomFunctions
-      || (this.options.projectType != null && _.toLower(this.options.projectType) == excelCustomFunctions)) { 
+      || (this.options.projectType != null && _.toLower(this.options.projectType) == excelCustomFunctions)) {
         isExcelFunctionsProject = true; }
 
       // Determine if we should prompt for script type. This is to address a bug that is causing Yo Office to crash in Node v10.10.0 - Issue #354
       // This is a temportary fix - we need to clean up the code in the next major version of the generator
       let promptForScriptType = !isManifestProject && this.options.js == null  && this.options.ts == null && (this.options.projectType != null && jsonData.projectBothScriptTypes(this.options.projectType)
       || answerForProjectType.projectType != null && jsonData.projectBothScriptTypes(answerForProjectType.projectType))
-      
+
       let answerForScriptType;
       let askForScriptType = [
         {
@@ -147,7 +147,7 @@ module.exports = yo.extend({
       }];
       let answerForName = await this.prompt(askForName);
       let endForName = (new Date()).getTime();
-      let durationForName = (endForName - startForName) / 1000; 
+      let durationForName = (endForName - startForName) / 1000;
 
       /* askForHost will be triggered if no project name was specified via the command line Host argument, and the Host argument
        * input was in fact valid, and the project type is not Excel-Functions */
@@ -171,8 +171,8 @@ module.exports = yo.extend({
       /* Gnerate Insights logging */
       const noElapsedTime = 0;
       insight.trackEvent('Name', { Name: this.project.name }, { durationForName });
-      insight.trackEvent('Host', { Host: this.project.host }, { durationForHost });    
-      insight.trackEvent('ScriptType', { ScriptType: this.project.scriptType }, { noElapsedTime });      
+      insight.trackEvent('Host', { Host: this.project.host }, { durationForHost });
+      insight.trackEvent('ScriptType', { ScriptType: this.project.scriptType }, { noElapsedTime });
       insight.trackEvent('IsManifestOnly', { IsManifestOnly: this.project.isManifestOnly.toString() }, { noElapsedTime });
       insight.trackEvent('ProjectType', { ProjectType: this.project.projectType }, { durationForProjectType });
     } catch (err) {
@@ -193,7 +193,7 @@ module.exports = yo.extend({
   },
 
   install: function () {
-    try {      
+    try {
       if (this.options['skip-install']) {
         this.installDependencies({
           npm: false,
@@ -216,7 +216,7 @@ module.exports = yo.extend({
 
   _configureProject: function(answerForProjectType, answerForScriptType, answerForHost, answerForName, isManifestProject, isExcelFunctionsProject)
   {
-    try 
+    try
     {
       this.project = {
         folder: this.options.output || answerForName.name || this.options.name,
@@ -244,7 +244,7 @@ module.exports = yo.extend({
       }
       else {
         this.project.hostInternalName = this.project.host;
-      }      
+      }
       this.destinationRoot(this.project.folder);
 
       /* Check to to see if destination folder already exists. If so, we will exit and prompt the user to provide
@@ -253,7 +253,7 @@ module.exports = yo.extend({
 
       let duration = this.project.duration;
       insight.trackEvent('App_Data', { AppID: this.project.projectId, Host: this.project.host, ProjectType: this.project.projectType, isTypeScript: (this.project.scriptType === typescript).toString() }, { duration });
-    } 
+    }
     catch (err) {
       insight.trackException(new Error('Configuration Error: ' + err));
     }
@@ -270,7 +270,7 @@ module.exports = yo.extend({
         let projectRepoBranchInfo = jsonData.getProjectRepoAndBranch(this.project.projectType, language);
 
         this._projectCreationMessage();
-        
+
         // Copy project template files from project repository (currently only custom functions has its own separate repo)
         if (projectRepoBranchInfo.repo)
         {
@@ -285,7 +285,7 @@ module.exports = yo.extend({
         else
         {
           /* Copy the manifest */
-          this.fs.copyTpl(this.templatePath(`hosts/${_.toLower(this.project.hostInternalName)}/manifest.xml`), this.destinationPath(`${this.project.projectInternalName}-manifest.xml`), templateFills);
+          this.fs.copyTpl(this.templatePath(`hosts/${_.toLower(this.project.hostInternalName)}/manifest.xml`), this.destinationPath('manifest.xml'), templateFills);
 
           if (this.project.isManifestOnly) {
             this.fs.copyTpl(this.templatePath(`manifest-only/**`), this.destinationPath(), templateFills);
@@ -296,7 +296,7 @@ module.exports = yo.extend({
 
                 /* Copy the project type specific overrides */
                 this.fs.copyTpl(this.templatePath(`${language}/${_.toLower(this.project.projectType)}/**`), this.destinationPath(), templateFills, null, { globOptions: { ignore: `**/*.placeholder` }});
-                      
+
                 /* Manually copy any dot files as yoeman can't handle them */
                 /* .babelrc */
                 const babelrcPath = this.templatePath(`${language}/${_.toLower(this.project.projectType)}/babelrc.placeholder`);
@@ -337,11 +337,11 @@ module.exports = yo.extend({
     /* Log to console the type of project being created */
     if (this.project.isManifestOnly)
       {
-        this.log('----------------------------------------------------------------------------------\n');  
-        this.log(`      Creating manifest for ${chalk.bold.green(this.project.projectDisplayName)} at ${chalk.bold.magenta(this._destinationRoot)}\n`);  
-        this.log('----------------------------------------------------------------------------------\n\n');  
+        this.log('----------------------------------------------------------------------------------\n');
+        this.log(`      Creating manifest for ${chalk.bold.green(this.project.projectDisplayName)} at ${chalk.bold.magenta(this._destinationRoot)}\n`);
+        this.log('----------------------------------------------------------------------------------\n\n');
       }
-    else 
+    else
       {
         this.log('\n----------------------------------------------------------------------------------\n');
         this.log(`      Creating ${chalk.bold.green(this.project.projectDisplayName)} add-in for ${chalk.bold.magenta(_.capitalize(this.project.host))} using ${chalk.bold.yellow(this.project.scriptType)} and ${chalk.bold.green(_.capitalize(this.project.projectType))} at ${chalk.bold.magenta(this._destinationRoot)}\n`);
@@ -376,15 +376,15 @@ module.exports = yo.extend({
   },
 
 _exitYoOfficeIfProjectFolderExists: function ()
-  {      
+  {
     if (helperMethods.doesProjectFolderExists(this._destinationRoot))
       {
-          this.log(`${chalk.bold.red(`\nFolder already exists at ${chalk.bold.green(this._destinationRoot)} and is not empty. To avoid accidentally overwriting any files, please start over and choose a different project name or destination folder via the ${chalk.bold.magenta(`--output`)} parameter`)}\n`); 
-          this._exitProcess(); 
+          this.log(`${chalk.bold.red(`\nFolder already exists at ${chalk.bold.green(this._destinationRoot)} and is not empty. To avoid accidentally overwriting any files, please start over and choose a different project name or destination folder via the ${chalk.bold.magenta(`--output`)} parameter`)}\n`);
+          this._exitProcess();
       }
       return false;
   },
-  
+
   _exitProcess: function () {
     process.exit();
   }

--- a/src/app/templates/js/angular/package.json
+++ b/src/app/templates/js/angular/package.json
@@ -5,9 +5,9 @@
   "version": "0.1.0",
   "scripts": {
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
-    "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
+    "sideload": "office-toolbox sideload -m manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m manifest.xml"
   },
   "dependencies": {
     "@angular/common": "^5.2.9",

--- a/src/app/templates/js/angular/resource.html
+++ b/src/app/templates/js/angular/resource.html
@@ -58,7 +58,7 @@ npm start</pre>
                 <% if (host === 'Outlook') { %>
                 <%# Outlook-specific steps go here %>
                 <p>Load the add-in into <%= host %>. The easiest way to do this is by sideloading the add-in using the in-client Office Store UI.</p>
-                
+
                 <pre>1. Open the Office Store, either in Outlook 2016 for Windows or Outlook on the web:
 
 &nbsp;&nbsp;&nbsp;&nbsp;- In Outlook 2016 for Windows, choose the <b>Store</b> button on the <b>Home</b> tab.
@@ -69,7 +69,7 @@ npm start</pre>
 
 3. Choose <b>Add from file...</b>.
 
-4. Browse to and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
+4. Browse to and select the manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
 
 5. Review the warning prompt and choose <b>Install</b>.
 
@@ -88,7 +88,7 @@ npm start</pre>
 # you'll see a link in the upper-right corner of the dialog box to Upload My add-in or Manage My Add-ins.</span>
 3. Manage My Add-ins will open a menu where you can then choose <b>Upload My add-in</b>.
 
-4. Choose <b>Browse</b> and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
+4. Choose <b>Browse</b> and select the manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
 
 5. Your add-in will load in <a target="_blank" href="https://office.live.com/start/<%= host %>.aspx?auth=2&nf=1" onclick="appInsights.trackEvent('linkClick_<%= host %>-sideload-step5');return true;"><%= host %></a>.</pre>
 
@@ -108,7 +108,7 @@ npm start</pre>
 
 <p>- Use the included <a target="_blank" href="https://github.com/officedev/office-addin-validator" onclick="appInsights.trackEvent('linkClick_office-addin-validator');return true;">Office Add-in Validator</a> to ensure your manifest.xml file is correct and complete. It will also give you information on against what platforms to test your add-in before submitting to the store.</p>
 <pre><span class="comment"># To validate your manifest, use the following command in your project directory:</span>
-$ npm run validate <%= projectInternalName %>-manifest.xml</pre>
+$ npm run validate manifest.xml</pre>
 <p>- Ensure your add-in works on all browsers and platforms that <a target="_blank" href="https://dev.office.com/add-in-availability">Office supports</a>.</p>
 
                     <p> For more information and resources to help you develop your add-in project, follow through the next steps

--- a/src/app/templates/js/jquery/package.json
+++ b/src/app/templates/js/jquery/package.json
@@ -5,9 +5,9 @@
   "version": "0.1.0",
   "scripts": {
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
-    "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
+    "sideload": "office-toolbox sideload -m manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/js/jquery/resource.html
+++ b/src/app/templates/js/jquery/resource.html
@@ -58,7 +58,7 @@ npm start</pre>
                 <% if (host === 'Outlook') { %>
                 <%# Outlook-specific steps go here %>
                 <p>Load the add-in into <%= host %>. The easiest way to do this is by sideloading the add-in using the in-client Office Store UI.</p>
-                
+
                 <pre>1. Open the Office Store, either in Outlook 2016 for Windows or Outlook on the web:
 
 &nbsp;&nbsp;&nbsp;&nbsp;- In Outlook 2016 for Windows, choose the <b>Store</b> button on the <b>Home</b> tab.
@@ -69,7 +69,7 @@ npm start</pre>
 
 3. Choose <b>Add from file...</b>.
 
-4. Browse to and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
+4. Browse to and select the manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
 
 5. Review the warning prompt and choose <b>Install</b>.
 
@@ -88,7 +88,7 @@ npm start</pre>
 # you'll see a link in the upper-right corner of the dialog box to Upload My add-in or Manage My Add-ins.</span>
 3. Manage My Add-ins will open a menu where you can then choose <b>Upload My add-in</b>.
 
-4. Choose <b>Browse</b> and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
+4. Choose <b>Browse</b> and select the manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
 
 5. Your add-in will load in <a target="_blank" href="https://office.live.com/start/<%= host %>.aspx?auth=2&nf=1" onclick="appInsights.trackEvent('linkClick_<%= host %>-sideload-step5');return true;"><%= host %></a>.</pre>
 
@@ -108,7 +108,7 @@ npm start</pre>
 
 <p>- Use the included <a target="_blank" href="https://github.com/officedev/office-addin-validator" onclick="appInsights.trackEvent('linkClick_office-addin-validator');return true;">Office Add-in Validator</a> to ensure your manifest.xml file is correct and complete. It will also give you information on against what platforms to test your add-in before submitting to the store.</p>
 <pre><span class="comment"># To validate your manifest, use the following command in your project directory:</span>
-$ npm run validate <%= projectInternalName %>-manifest.xml</pre>
+$ npm run validate manifest.xml</pre>
 <p>- Ensure your add-in works on all browsers and platforms that <a target="_blank" href="https://dev.office.com/add-in-availability">Office supports</a>.</p>
 
                     <p> For more information and resources to help you develop your add-in project, follow through the next steps

--- a/src/app/templates/manifest-only/package.json
+++ b/src/app/templates/manifest-only/package.json
@@ -4,7 +4,7 @@
   "author": "",
   "version": "0.1.0",
   "scripts": {
-    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m manifest.xml"
   },
   "dependencies": {
     "office-toolbox": "^0.1.0"

--- a/src/app/templates/manifest-only/resource.html
+++ b/src/app/templates/manifest-only/resource.html
@@ -58,7 +58,7 @@ npm start</pre>
                 <% if (host === 'Outlook') { %>
                 <%# Outlook-specific steps go here %>
                 <p>Load the add-in into <%= host %>. The easiest way to do this is by sideloading the add-in using the in-client Office Store UI.</p>
-                
+
                 <pre>1. Open the Office Store, either in Outlook 2016 for Windows or Outlook on the web:
 
 &nbsp;&nbsp;&nbsp;&nbsp;- In Outlook 2016 for Windows, choose the <b>Store</b> button on the <b>Home</b> tab.
@@ -69,7 +69,7 @@ npm start</pre>
 
 3. Choose <b>Add from file...</b>.
 
-4. Browse to and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
+4. Browse to and select the manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
 
 5. Review the warning prompt and choose <b>Install</b>.
 
@@ -88,7 +88,7 @@ npm start</pre>
 # you'll see a link in the upper-right corner of the dialog box to Upload My add-in or Manage My Add-ins.</span>
 3. Manage My Add-ins will open a menu where you can then choose <b>Upload My add-in</b>.
 
-4. Choose <b>Browse</b> and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
+4. Choose <b>Browse</b> and select the manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
 
 5. Your add-in will load in <a target="_blank" href="https://office.live.com/start/<%= host %>.aspx?auth=2&nf=1" onclick="appInsights.trackEvent('linkClick_<%= host %>-sideload-step5');return true;"><%= host %></a>.</pre>
 
@@ -108,7 +108,7 @@ npm start</pre>
 
 <p>- Use the included <a target="_blank" href="https://github.com/officedev/office-addin-validator" onclick="appInsights.trackEvent('linkClick_office-addin-validator');return true;">Office Add-in Validator</a> to ensure your manifest.xml file is correct and complete. It will also give you information on against what platforms to test your add-in before submitting to the store.</p>
 <pre><span class="comment"># To validate your manifest, use the following command in your project directory:</span>
-$ npm run validate <%= projectInternalName %>-manifest.xml</pre>
+$ npm run validate manifest.xml</pre>
 <p>- Ensure your add-in works on all browsers and platforms that <a target="_blank" href="https://dev.office.com/add-in-availability">Office supports</a>.</p>
 
                     <p> For more information and resources to help you develop your add-in project, follow through the next steps

--- a/src/app/templates/ts/angular/package.json
+++ b/src/app/templates/ts/angular/package.json
@@ -5,9 +5,9 @@
   "version": "0.1.0",
   "scripts": {
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
-    "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
+    "sideload": "office-toolbox sideload -m manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m manifest.xml"
   },
   "dependencies": {
     "office-toolbox": "^0.1.0",

--- a/src/app/templates/ts/angular/resource.html
+++ b/src/app/templates/ts/angular/resource.html
@@ -58,7 +58,7 @@ npm start</pre>
                 <% if (host === 'Outlook') { %>
                 <%# Outlook-specific steps go here %>
                 <p>Load the add-in into <%= host %>. The easiest way to do this is by sideloading the add-in using the in-client Office Store UI.</p>
-                
+
                 <pre>1. Open the Office Store, either in Outlook 2016 for Windows or Outlook on the web:
 
 &nbsp;&nbsp;&nbsp;&nbsp;- In Outlook 2016 for Windows, choose the <b>Store</b> button on the <b>Home</b> tab.
@@ -69,7 +69,7 @@ npm start</pre>
 
 3. Choose <b>Add from file...</b>.
 
-4. Browse to and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
+4. Browse to and select the manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
 
 5. Review the warning prompt and choose <b>Install</b>.
 
@@ -88,7 +88,7 @@ npm start</pre>
 # you'll see a link in the upper-right corner of the dialog box to Upload My add-in or Manage My Add-ins.</span>
 3. Manage My Add-ins will open a menu where you can then choose <b>Upload My add-in</b>.
 
-4. Choose <b>Browse</b> and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
+4. Choose <b>Browse</b> and select the manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
 
 5. Your add-in will load in <a target="_blank" href="https://office.live.com/start/<%= host %>.aspx?auth=2&nf=1" onclick="appInsights.trackEvent('linkClick_<%= host %>-sideload-step5');return true;"><%= host %></a>.</pre>
 
@@ -108,7 +108,7 @@ npm start</pre>
 
 <p>- Use the included <a target="_blank" href="https://github.com/officedev/office-addin-validator" onclick="appInsights.trackEvent('linkClick_office-addin-validator');return true;">Office Add-in Validator</a> to ensure your manifest.xml file is correct and complete. It will also give you information on against what platforms to test your add-in before submitting to the store.</p>
 <pre><span class="comment"># To validate your manifest, use the following command in your project directory:</span>
-$ npm run validate <%= projectInternalName %>-manifest.xml</pre>
+$ npm run validate manifest.xml</pre>
 <p>- Ensure your add-in works on all browsers and platforms that <a target="_blank" href="https://dev.office.com/add-in-availability">Office supports</a>.</p>
 
                     <p> For more information and resources to help you develop your add-in project, follow through the next steps

--- a/src/app/templates/ts/jquery/package.json
+++ b/src/app/templates/ts/jquery/package.json
@@ -5,9 +5,9 @@
   "version": "0.1.0",
   "scripts": {
     "start": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 3000",
-    "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
+    "sideload": "office-toolbox sideload -m manifest.xml -a <%= hostInternalName %>",
     "build": "webpack --mode production",
-    "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
+    "validate": "office-toolbox validate -m manifest.xml"
   },
   "dependencies": {
     "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/ts/jquery/resource.html
+++ b/src/app/templates/ts/jquery/resource.html
@@ -58,7 +58,7 @@ npm start</pre>
                 <% if (host === 'Outlook') { %>
                 <%# Outlook-specific steps go here %>
                 <p>Load the add-in into <%= host %>. The easiest way to do this is by sideloading the add-in using the in-client Office Store UI.</p>
-                
+
                 <pre>1. Open the Office Store, either in Outlook 2016 for Windows or Outlook on the web:
 
 &nbsp;&nbsp;&nbsp;&nbsp;- In Outlook 2016 for Windows, choose the <b>Store</b> button on the <b>Home</b> tab.
@@ -69,7 +69,7 @@ npm start</pre>
 
 3. Choose <b>Add from file...</b>.
 
-4. Browse to and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
+4. Browse to and select the manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
 
 5. Review the warning prompt and choose <b>Install</b>.
 
@@ -88,7 +88,7 @@ npm start</pre>
 # you'll see a link in the upper-right corner of the dialog box to Upload My add-in or Manage My Add-ins.</span>
 3. Manage My Add-ins will open a menu where you can then choose <b>Upload My add-in</b>.
 
-4. Choose <b>Browse</b> and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
+4. Choose <b>Browse</b> and select the manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
 
 5. Your add-in will load in <a target="_blank" href="https://office.live.com/start/<%= host %>.aspx?auth=2&nf=1" onclick="appInsights.trackEvent('linkClick_<%= host %>-sideload-step5');return true;"><%= host %></a>.</pre>
 
@@ -108,7 +108,7 @@ npm start</pre>
 
 <p>- Use the included <a target="_blank" href="https://github.com/officedev/office-addin-validator" onclick="appInsights.trackEvent('linkClick_office-addin-validator');return true;">Office Add-in Validator</a> to ensure your manifest.xml file is correct and complete. It will also give you information on against what platforms to test your add-in before submitting to the store.</p>
 <pre><span class="comment"># To validate your manifest, use the following command in your project directory:</span>
-$ npm run validate <%= projectInternalName %>-manifest.xml</pre>
+$ npm run validate manifest.xml</pre>
 <p>- Ensure your add-in works on all browsers and platforms that <a target="_blank" href="https://dev.office.com/add-in-availability">Office supports</a>.</p>
 
                     <p> For more information and resources to help you develop your add-in project, follow through the next steps

--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -7,9 +7,9 @@
         "clean": "rimraf dist && rimraf .awcache",
         "lint": "tslint --project tsconfig.json",
         "start": "webpack-dev-server --inline --config config/webpack.dev.js --progress",
-        "sideload": "office-toolbox sideload -m <%= projectInternalName %>-manifest.xml -a <%= hostInternalName %>",
+        "sideload": "office-toolbox sideload -m manifest.xml -a <%= hostInternalName %>",
         "build": "npm run clean && webpack --config config/webpack.prod.js --colors --progress --bail",
-        "validate": "office-toolbox validate -m <%= projectInternalName %>-manifest.xml"
+        "validate": "office-toolbox validate -m manifest.xml"
     },
     "dependencies": {
         "@microsoft/office-js-helpers": "^1.0.1",

--- a/src/app/templates/ts/react/resource.html
+++ b/src/app/templates/ts/react/resource.html
@@ -58,7 +58,7 @@ npm start</pre>
                 <% if (host === 'Outlook') { %>
                 <%# Outlook-specific steps go here %>
                 <p>Load the add-in into <%= host %>. The easiest way to do this is by sideloading the add-in using the in-client Office Store UI.</p>
-                
+
                 <pre>1. Open the Office Store, either in Outlook 2016 for Windows or Outlook on the web:
 
 &nbsp;&nbsp;&nbsp;&nbsp;- In Outlook 2016 for Windows, choose the <b>Store</b> button on the <b>Home</b> tab.
@@ -69,7 +69,7 @@ npm start</pre>
 
 3. Choose <b>Add from file...</b>.
 
-4. Browse to and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
+4. Browse to and select the manifest.xml file from the root of the project folder, and then choose <b>Open</b>.
 
 5. Review the warning prompt and choose <b>Install</b>.
 
@@ -88,7 +88,7 @@ npm start</pre>
 # you'll see a link in the upper-right corner of the dialog box to Upload My add-in or Manage My Add-ins.</span>
 3. Manage My Add-ins will open a menu where you can then choose <b>Upload My add-in</b>.
 
-4. Choose <b>Browse</b> and select the <%= projectInternalName %>-manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
+4. Choose <b>Browse</b> and select the manifest.xml file from the root of the project folder, and then choose <b>Upload</b>.
 
 5. Your add-in will load in <a target="_blank" href="https://office.live.com/start/<%= host %>.aspx?auth=2&nf=1" onclick="appInsights.trackEvent('linkClick_<%= host %>-sideload-step5');return true;"><%= host %></a>.</pre>
 
@@ -108,7 +108,7 @@ npm start</pre>
 
 <p>- Use the included <a target="_blank" href="https://github.com/officedev/office-addin-validator" onclick="appInsights.trackEvent('linkClick_office-addin-validator');return true;">Office Add-in Validator</a> to ensure your manifest.xml file is correct and complete. It will also give you information on against what platforms to test your add-in before submitting to the store.</p>
 <pre><span class="comment"># To validate your manifest, use the following command in your project directory:</span>
-$ npm run validate <%= projectInternalName %>-manifest.xml</pre>
+$ npm run validate manifest.xml</pre>
 <p>- Ensure your add-in works on all browsers and platforms that <a target="_blank" href="https://dev.office.com/add-in-availability">Office supports</a>.</p>
 
                     <p> For more information and resources to help you develop your add-in project, follow through the next steps

--- a/src/test/manifest-only-project.ts
+++ b/src/test/manifest-only-project.ts
@@ -11,6 +11,7 @@ const manifestProject = 'Manifest';
 
 const expectedFiles = [
   'package.json',
+  'manifest.xml',
   'assets/icon-16.png',
   'assets/icon-32.png',
   'assets/icon-80.png',
@@ -36,13 +37,11 @@ const unexpectedFiles = [
  */
 describe('manifest project - answers', () => {
   let projectDisplayName = 'My Office Add-in';
-  let projectEscapedName = 'my-office-add-in';
   let answers = {
     projectType: manifestProject,
     name: projectDisplayName,
-    host: 'Excel',    
+    host: 'Excel',
   };
-  let manifestFileName = projectEscapedName + '-manifest.xml';
 
 	/** Test addin when user chooses jquery and typescript. */
   describe('manifest', () => {
@@ -51,12 +50,7 @@ describe('manifest project - answers', () => {
     });
 
     it('creates expected files', (done) => {
-      let expected = [
-        manifestFileName,
-        ...expectedFiles
-      ];
-
-      assert.file(expected);
+      assert.file(expectedFiles);
       assert.noFile(unexpectedFiles);
       done();
     });
@@ -87,16 +81,7 @@ describe('manifest project - answers & args - jquery & typescript', () => {
     });
 
     it('creates expected files', (done) => {
-      let name = argument[1] ? argument[1] : answers.name;
-      let host = argument[2] ? argument[2] : answers.host;      
-      let manifestFileName = name  + '-manifest.xml';
-
-      let expected = [
-        manifestFileName,
-        ...expectedFiles
-      ];
-
-      assert.file(expected);
+      assert.file(expectedFiles);
       assert.noFile(unexpectedFiles);
       done();
     });
@@ -109,7 +94,7 @@ describe('manifest project - answers & args - jquery & typescript', () => {
   describe('arguments: project name', () => {
     before((done) => {
       let answers = {
-        name: projectEscapedName,       
+        name: projectEscapedName,
         host: 'Excel'
       };
       argument[0] = manifestProject;
@@ -119,16 +104,7 @@ describe('manifest project - answers & args - jquery & typescript', () => {
     });
 
     it('creates expected files', (done) => {
-      let name = argument[1] ? argument[1] : answers.name;
-      let host = argument[2] ? argument[2] : answers.host;      
-      let manifestFileName = name  + '-manifest.xml';
-
-      let expected = [
-        manifestFileName,
-        ...expectedFiles
-      ];
-
-      assert.file(expected);
+      assert.file(expectedFiles);
       assert.noFile(unexpectedFiles);
       done();
     });
@@ -147,16 +123,7 @@ describe('manifest project - answers & args - jquery & typescript', () => {
     });
 
     it('creates expected files', (done) => {
-      let name = argument[1] ? argument[1] : answers.name;
-      let host = argument[2] ? argument[2] : answers.host;      
-      let manifestFileName = name  + '-manifest.xml';
-
-      let expected = [
-        manifestFileName,
-        ...expectedFiles
-      ];
-
-      assert.file(expected);
+      assert.file(expectedFiles);
       assert.noFile(unexpectedFiles);
       done();
     });

--- a/src/test/new-project.ts
+++ b/src/test/new-project.ts
@@ -7,6 +7,8 @@ import * as helpers from 'yeoman-test';
 import * as assert from 'yeoman-assert';
 import * as path from 'path';
 
+const expectedManifestFile = 'manifest.xml';
+
 const expectedAssets = [
   'assets/icon-16.png',
   'assets/icon-32.png',
@@ -45,6 +47,7 @@ const commonExpectedFiles = [
 
 const expectExcelCustomFunctionFiles = [
   ...certificateFiles,
+  expectedManifestFile,
   '.gitignore',
   'package.json',
   'webpack.config.js',
@@ -54,24 +57,23 @@ const expectExcelCustomFunctionFiles = [
   'config/customfunctions.json',
 ];
 
+
 /**
  * Test addin from user answers
  * new project, default folder, default host.
  */
 describe('Create new project from prompts only', () => {
   let projectDisplayName = 'My Office Add-in';
-  let projectEscapedName = 'my-office-add-in';
   let answers = {
     projectType: null,
-    scriptType: null,    
+    scriptType: null,
     name: projectDisplayName,
-    host: 'Excel'    
+    host: 'Excel'
   };
-  let manifestFileName = projectEscapedName + '-manifest.xml';
 
   /** Test addin when user chooses jquery and typescript. */
   describe('jquery & typescript', () => {
-    before((done) => {      
+    before((done) => {
       answers.projectType = 'Jquery';
       answers.scriptType = 'Typescript';
       helpers.run(path.join(__dirname, '../app'))
@@ -81,10 +83,10 @@ describe('Create new project from prompts only', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         'app.css',
         'tsconfig.json',
         'src/index.ts',
@@ -108,10 +110,10 @@ describe('Create new project from prompts only', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesJs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         '.babelrc',
         'app.css',
         'src/index.js',
@@ -135,10 +137,10 @@ describe('Create new project from prompts only', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         '.babelrc',
         'app.css',
         'tsconfig.json',
@@ -163,10 +165,10 @@ describe('Create new project from prompts only', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesJs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         '.babelrc',
         'app.css',
         'jsconfig.json',
@@ -194,10 +196,10 @@ describe('Create new project from prompts only', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         'tsconfig.json',
         'config/webpack.common.js',
         'config/webpack.dev.js',
@@ -229,7 +231,7 @@ describe('Create new project from prompts and command line overrides', () => {
     scriptType: null,
     projectType: null,
     name: null,
-    host: null  
+    host: null
   };
   let argument = [];
 
@@ -241,7 +243,7 @@ describe('Create new project from prompts and command line overrides', () => {
     before((done) => {
       answers.name = projectEscapedName;
       answers.scriptType = 'Typescript';
-      answers.host = 'Excel';      
+      answers.host = 'Excel';
       argument[0] = 'Jquery';
 
       helpers.run(path.join(__dirname, '../app'))
@@ -251,15 +253,12 @@ describe('Create new project from prompts and command line overrides', () => {
     });
 
     it('creates expected files', (done) => {
-      let host = argument[2] ? argument[2] : answers.host;
-      let name = argument[1] ? argument[1] : answers.name;
-      let manifestFileName = name + '-manifest.xml';
 
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         'app.css',
         'tsconfig.json',
         'src/index.ts',
@@ -290,15 +289,12 @@ describe('Create new project from prompts and command line overrides', () => {
     });
 
     it('creates expected files', (done) => {
-      let host = argument[2] ? argument[2] : answers.host;
-      let name = argument[1] ? argument[1] : answers.name;
-      let manifestFileName = name + '-manifest.xml';
 
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         'app.css',
         'tsconfig.json',
         'src/index.ts',
@@ -318,7 +314,7 @@ describe('Create new project from prompts and command line overrides', () => {
     before((done) => {
       argument[0] = 'Jquery';
       argument[1] = projectEscapedName;
-      argument[2] = 'Excel';      
+      argument[2] = 'Excel';
 
       helpers.run(path.join(__dirname, '../app'))
         .withArguments(argument)
@@ -327,15 +323,12 @@ describe('Create new project from prompts and command line overrides', () => {
     });
 
     it('creates expected files', (done) => {
-      let host = argument[2] ? argument[2] : answers.host;
-      let name = argument[1] ? argument[1] : answers.name;
-      let manifestFileName = name + '-manifest.xml';
 
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         'app.css',
         'tsconfig.json',
         'src/index.ts',
@@ -363,12 +356,8 @@ describe('Create new project from prompts and command line overrides', () => {
 
     it('creates expected files', (done) => {
       let name = argument[1] ? argument[1] : answers.name;
-      let manifestFileName = 'manifest.xml';     
 
-      let expected = [
-        manifestFileName,
-        ...expectExcelCustomFunctionFiles       
-      ];
+      let expected = expectExcelCustomFunctionFiles;
 
       // assert.file(expected);
       done();
@@ -382,15 +371,13 @@ describe('Create new project from prompts and command line overrides', () => {
  */
 describe('Create new project from prompts with command line options', () => {
   let projectDisplayName = 'My Office Add-in';
-  let projectEscapedName = 'my-office-add-in';
   let answers = {
     scriptType: null,
-    projectType: 'Jquery',    
+    projectType: 'Jquery',
     name: projectDisplayName,
-    host: 'Excel'   
+    host: 'Excel'
   };
 
-  let manifestFileName = projectEscapedName + '-manifest.xml';
 
   /** Test addin when user pass in --js. */
   describe(' --js', () => {
@@ -403,10 +390,10 @@ describe('Create new project from prompts with command line options', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesJs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         '.babelrc',
         'app.css',
         'src/index.js',
@@ -430,10 +417,10 @@ describe('Create new project from prompts with command line options', () => {
 
     it('creates expected files', (done) => {
       let expected = [
-        manifestFileName,
         ...expectedAssets,
         ...expectedFunctionFilesTs,
         ...commonExpectedFiles,
+        expectedManifestFile,
         'app.css',
         'tsconfig.json',
         'src/index.ts',
@@ -443,7 +430,7 @@ describe('Create new project from prompts with command line options', () => {
       assert.file(expected);
       done();
     });
-  }); 
+  });
 
     /** Test addin when user passes in --output. */
     let folderName = 'testFolder';
@@ -452,7 +439,7 @@ describe('Create new project from prompts with command line options', () => {
         scriptType: 'Typescript',
         projectType: 'Manifest',
         name: projectDisplayName,
-        host: 'Excel'   
+        host: 'Excel'
       };
       before((done) => {
         helpers.run(path.join(__dirname, '../app'))
@@ -460,21 +447,21 @@ describe('Create new project from prompts with command line options', () => {
           .withPrompts(answers)
           .on('end', done);
       });
-  
+
       it('creates expected files', (done) => {
         let expected = [
-           manifestFileName,
           ...expectedAssets,
+          expectedManifestFile,
           'package.json',
           'resource.html'
-        ];  
+        ];
 
         // Ensure manifest is found in expected output folder
-        assert.ok(path.win32.resolve(manifestFileName).toString().indexOf(folderName) >=0, 'manifest file not found in specified output folder');
+        assert.ok(path.win32.resolve(expectedManifestFile).toString().indexOf(folderName) >=0, 'manifest file not found in specified output folder');
 
         // Verify expected files were created
         assert.file(expected);
         done();
       });
-    });    
+    });
 });


### PR DESCRIPTION
By removing the projectInternalName from the manifest filename, package.json files can be simplified. fixes #370