### PR TITLE
Fix for https://github.com/OfficeDev/generator-office/issues/346

### DIFF
--- a/src/app/templates/ts/base/function-file/function-file.html
+++ b/src/app/templates/ts/base/function-file/function-file.html
@@ -11,7 +11,7 @@
     <!-- Office JavaScript API -->
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.debug.js"></script>
 
-    <script type="text/javascript" src="function-file.js"></script>
+    <script type="text/javascript" src="../function-file.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
- Function-file.html points to the wrong location for function-file.js
- This issue only affects the Angular TS template. The fix is to just update the location of function-file.js in Function-file.html.
- I validated the change by moving all the sample code for that sets cells in Excel over to function-file.ts, and the ensuring that the code in function-file.js gets called during execution of the add-in