### PR TITLE
rollback expected files for custom-functions

### DIFF
--- a/src/test/new-project.ts
+++ b/src/test/new-project.ts
@@ -53,16 +53,10 @@ const expectExcelCustomFunctionFiles = [
   '.gitignore',
   'package.json',
   'webpack.config.js',
-  'assets/icon-16.png',
-  'assets/icon-32.png',
-  'assets/icon-80.png',
-  'assets/logo-filled.png',
-  'src/functions/functions.html',
-  'src/functions/functions.ts',
-  'src/functions/functions.json',
-  'src/taskpane/taskpane.css',
-  'src/taskpane/taskpane.html',
-  'src/taskpane/taskpane.ts',
+  'config/web.config',
+  'index.html',
+  'src/customfunctions.ts',
+  'config/customfunctions.json',
 ];
 
 


### PR DESCRIPTION
The yo-office branch for github.com/OfficeDev/Excel-Custom-Functions was rolled back to the Sept 2018 preview.
This updates the expected files to match.

This can be reverted later, once the yo-office branch is updated to master.