### PR TITLE
fixed ts-loader used for typescipt/angular

### DIFF
--- a/src/app/templates/ts/angular/webpack.config.js
+++ b/src/app/templates/ts/angular/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
             {
                 test: /\.ts$/,
                 exclude: /node_modules/,
-                use: 'babel-loader'
+                use: 'ts-loader'
             },
             {
                 test: /\.html$/,


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
    Unable to successfully compile without it. e.g. will break if "private/public" used or type casting.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Describe manual testing done. 

Changed. Was able to compile typescript-based frontend. Reverted. Threw errors. 
Not entirely scientific but it is a consistently repeatable/observable outcome.

<img width="681" alt="screen shot 2019-01-21 at 9 58 13 pm" src="https://user-images.githubusercontent.com/132126/51473282-b42c2480-1dc7-11e9-9adc-6262e8c7b8e6.png">


4. **Platforms tested**:

    > * [ ] Windows
    > * [x] Mac
