### PR TITLE
Update Yo Office to automatically CD to new project folder

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -5,6 +5,7 @@
 import * as _ from 'lodash';
 import * as appInsights from 'applicationinsights';
 import * as chalk from 'chalk';
+import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as path from "path";
 import * as uuid from 'uuid/v4';
@@ -335,6 +336,7 @@ module.exports = yo.extend({
     this.log(`      Please refer to resource.html in your project for more information.`);
     this.log(`      Or visit our repo at: https://github.com/officeDev/generator-office \n`);
     this.log('----------------------------------------------------------------------------------------------------------\n');
+    this._openProjectFolder();
     this._exitProcess();
   },
 
@@ -391,7 +393,20 @@ _exitYoOfficeIfProjectFolderExists: function ()
       return false;
   },
 
-  _exitProcess: function () {
+  _openProjectFolder: function () {
+    try {
+      let cmdLine: string;
+      if (process.platform === "win32") {
+        cmdLine = `start cmd.exe /K "cd /d ${this._destinationRoot}"`
+      } else {
+        cmdLine = `open -a Terminal ${this._destinationRoot}`
+      }
+      this.log(`\nOpening project folder at ${chalk.bold.magenta(this._destinationRoot)} in new command prompt\n`);
+      childProcess.execSync(cmdLine);
+    } catch (err) { console.log(`Error trying to open project folder: ${err}`)}
+  },
+
+  _exitProcess: function () {    ;
     process.exit();
   }
 } as any);


### PR DESCRIPTION
- At the end of project creation, yo office will open a new command prompt and cd to the project folder
- Verfied works on Windows and Mac.  Had no way to verify on Linux but from what I've read opening a new prompt should work the same as it does on Mac.

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [X ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
Will open command prompt and cd to new project folder


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x ]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Tested on Windows and Mac

4. **Platforms tested**:

    > * [X ] Windows
    > * [X ] Mac
