### PR TITLE
Update office-ui-fabric-react to 6.138.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1364,7 +1364,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1385,12 +1386,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1405,17 +1408,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1532,7 +1538,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1544,6 +1551,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1558,6 +1566,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1565,12 +1574,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1589,6 +1600,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1669,7 +1681,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1681,6 +1694,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1766,7 +1780,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1802,6 +1817,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1821,6 +1837,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1864,12 +1881,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2474,9 +2493,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "applicationinsights": "^0.18.0",
     "chalk": "^1.1.3",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "office-addin-manifest": "^1.2.0",
     "opn": "^4.0.2",
     "rimraf": "^2.6.2",

--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -6,23 +6,23 @@
     "scripts": {
         "clean": "rimraf dist && rimraf .awcache",
         "lint": "tslint --project tsconfig.json",
-        "start": "webpack-dev-server --inline --config config/webpack.dev.js --progress",
+        "start": "webpack-dev-server --inline --mode development --config config/webpack.dev.js --progress",
         "sideload": "office-toolbox sideload -m manifest.xml -a <%= hostInternalName %>",
-        "build": "npm run clean && webpack --config config/webpack.prod.js --colors --progress --bail",
+        "build": "npm run clean && webpack --mode production --config config/webpack.prod.js --colors --progress --bail",
         "validate": "office-toolbox validate -m manifest.xml"
     },
     "dependencies": {
         "@microsoft/office-js-helpers": "^1.0.2",
         "core-js": "^2.6.1",
-        "office-ui-fabric-react": "^5.134.0",
-        "react": "^16.7.0",
-        "react-dom": "^16.7.0"
+        "office-ui-fabric-react": "^6.138.1",
+        "react": "^16.8.1",
+        "react-dom": "^16.8.1"
     },
     "devDependencies": {
-        "@types/office-js": "0.0.140",
-        "@types/react": "^16.7.18",
-        "@types/react-dom": "^16.0.11",
-        "@types/react-hot-loader": "^3.0.6",
+        "@types/office-js": "0.0.155",
+        "@types/react": "^16.8.2",
+        "@types/react-dom": "^16.8.0",
+        "@types/react-hot-loader": "^4.1.0",
         "@types/webpack": "4.4.22",
         "@types/webpack-dev-server": "3.1.1",
         "autoprefixer": "6.7.7",


### PR DESCRIPTION
- There is a security vulnerability in the older version of office-ui-fabric-react  so udpating to latest version
- Also updating all other packages to latest versions

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [ X]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [X ]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

   Locally installed, built and ran React project for Excel and everything worked

4. **Platforms tested**:

    > * [X ] Windows
    > * [ ] Mac

Louis is going to test the changes on Mac
