### PR TITLE
Simplifying macOS certificate registration steps

### DIFF
--- a/src/docs/ssl.md
+++ b/src/docs/ssl.md
@@ -12,43 +12,23 @@ To fix this, you need to configure your developer workstation to trust the self-
 
 ## Table of Contents
 
-* [OS X](#os-x)
-  * [Get certificate in Chrome](#get-certificate-in-chrome)
-  * [Get certificate file from project directory](#get-certificate-file-from-project-directory)
-  * [Add certification file to Key Chain Access](#add-certification-file-to-key-chain-access)
+* [macOS](#macOS)
 * [Windows](#windows)
 
-## [OS X](https://support.apple.com/kb/PH18677)
+## macOS
 
-#### Get certificate in Chrome
-
-1. Start Chrome and do the following:
-   1. Open Developer Tools window by using keyboard shortcuts: Cmd + Opt + I.
-   1. Click to go to 'security' panel and 'overview' screen.
-	 1. Click 'View certificate'. 
-
-   ![](assets/ssl-chrome-devtool.png)
-
-1. Click and drag the image to your desktop. It looks like a little certificate.
-![](assets/ssl-chrome-getcert.png)
-
-#### Get certificate file from project directory
-
-You can locate the server.crt file at **~/your_yo_office_project/certs/server.crt**
-
-#### Add certification file to Key Chain Access
-
-1. Open the **Keychain Access** utility in OS X.
-   1. Select the **System** option on the left.
-   1. Click the lock icon in the upper-left corner to enable changes.
-   ![](assets/ssl-keychain-01.png)
-
-   1. Click the plus button at the bottom and select the **localhost.cer** file you copied to the desktop.
-   1. In the dialog that comes up, click **Always Trust**.
-   1. After **localhost** gets added to the **System** keychain, double-click it to open it again.
-   1. Expand the **Trust** section and for the first option, pick **Always Trust**.
-
-  ![](assets/ssl-keychain-02.png)
+1. In Chrome, open the [Settings](chrome://settings) window.
+2. Expand the **Advanced** section and choose **Manage certficiates**.
+    
+    The **Keychain Access** utility will open.
+    
+3. Double-click the **localhost-ca** certificate.
+4. In the **Trust** section, set the following value
+    
+    **When using this certificate**: **Always Trust**
+    
+5. Close the dialog.
+6. You'll be prompted for your credentials and will need to enter them to enable the certificate
   
 At this point everything has been configured. Quit all browsers, then reopen and try to navigate to the local HTTPS site. The browser should report it as a valid certificate:
 

--- a/src/docs/ssl.md
+++ b/src/docs/ssl.md
@@ -17,19 +17,19 @@ To fix this, you need to configure your developer workstation to trust the self-
 
 ## macOS
 
-1. In Chrome, open the [Settings](chrome://settings) window.
-2. Expand the **Advanced** section and choose **Manage certficiates**.
-    
-    The **Keychain Access** utility will open.
-    
-3. Double-click the **localhost-ca** certificate.
-4. In the **Trust** section, set the following value
+1. In **Finder**, open the **certs** folder in the root folder of your project.
+2. Double-click the **ca.crt** file.
+3. In the **Add Certificates** dialog box, choose **Add**. 
+4. You'll be prompted for your credentials. Enter your credentials and choose **Modify Keychain**.
+5. Open the **Keychain Access** utility.
+6. Select the **Certificates** category, and double-click the **localhost-ca** certificate.
+7. In the **Trust** section, set the following value
     
     **When using this certificate**: **Always Trust**
     
-5. Close the dialog.
-6. You'll be prompted for your credentials and will need to enter them to enable the certificate
-  
+8. Close the dialog.
+9. You'll be prompted for your credentials and will need to enter them to enable the certificate
+   
 At this point everything has been configured. Quit all browsers, then reopen and try to navigate to the local HTTPS site. The browser should report it as a valid certificate:
 
   ![](assets/ssl-chrome-good.png)


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [X]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [X]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
I believe this is a simpler way to register certs on a mac.

3. **Validation/testing performed**:

    Describe manual testing done. 
I tested on a mac, but would be good to have someone double-check these steps.

4. **Platforms tested**:

    > * [ ] Windows
    > * [X] Mac
