### PR TITLE
Upgrade Fabric UI

### DIFF
--- a/src/app/templates/ts/react/package.json
+++ b/src/app/templates/ts/react/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@microsoft/office-js-helpers": "^1.0.2",
         "core-js": "^2.6.1",
-        "office-ui-fabric-react": "^6.138.1",
+        "office-ui-fabric-react": "^6.161.0",
         "react": "^16.8.1",
         "react-dom": "^16.8.1"
     },

--- a/src/app/templates/ts/react/src/index.html
+++ b/src/app/templates/ts/react/src/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.debug.js"></script>
 </head>
 
-<body class="ms-font-m">
+<body class="ms-Fabric ms-font-m">
     <div id="container"></div>
 </body>
 

--- a/src/app/templates/ts/react/src/index.tsx
+++ b/src/app/templates/ts/react/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
-import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
+import { initializeIcons } from '@uifabric/icons';
 
 import App from './components/App';
 


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.

Uses the current available UI Fabric, and changed references to Fabric Styling works from the start

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

- Ensured `npm i` was successful
- Built and ran
- Styling was as expected

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
