### PR TITLE
Bundle React by default.

### DIFF
--- a/src/app/templates/ts/react/config/webpack.prod.js
+++ b/src/app/templates/ts/react/config/webpack.prod.js
@@ -6,11 +6,6 @@ const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 module.exports = webpackMerge(commonConfig, {
     devtool: 'source-map',
 
-    externals: {
-        'react': 'React',
-        'react-dom': 'ReactDOM'
-    },
-
     performance: {
         hints: "warning"
     },


### PR DESCRIPTION
Currently, the webpack configuration for the production build marks React and React-DOM as external. This means that out-of-the-box a React add-in works in the development environment but when you go to production build it will result in error that React is undefined, because it is not included in the bundle, nor is it referenced explicitly with script links in the HTML page. This change will result in React being bundled by default. This will add about 3Mb to the bundle, but the client has to load this one way or another. You could explain in the documentation how to omit React from the bundle and use a script link to a CDN to load the React libraries if that is the developer's preference.

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
config/webpack.prod.js

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    All tests passing. Also manually tested that issue is resolved
4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
