### PR TITLE
Fix for React project template

### DIFF
--- a/src/app/helpers/helperMethods.ts
+++ b/src/app/helpers/helperMethods.ts
@@ -61,7 +61,7 @@ export namespace helperMethods {
 
     async function convertProjectToSingleHost(projectFolder: string, projectType: string, host: string, typescript: boolean): Promise<void> {        
         try {
-            const extension = typescript ? "ts" : "js";
+            let extension = typescript ? "ts" : "js";
             // copy host-specific manifest over manifest.xml
             const manifestContent: any = await readFileAsync(path.resolve(`${projectFolder}/manifest.${host}.xml`), 'utf8');
             await writeFileAsync(path.resolve(`${projectFolder}/manifest.xml`), manifestContent);
@@ -96,6 +96,7 @@ export namespace helperMethods {
                 case "react":
                 {
                     // copy host-specific App.tsx[js] over src/taskpane/app/components/App.tsx[js]
+                    extension = typescript ? "tsx" : "js";
                     const srcContent = await readFileAsync(path.resolve(`${projectFolder}/src/taskpane/components/${_.upperFirst(host)}.App.${extension}`), 'utf8');
                     await writeFileAsync(path.resolve(`${projectFolder}/src/taskpane/components/App.${extension}`), srcContent);
 


### PR DESCRIPTION
- Was incorrectly specifying .ts for React projects. Should be .tsx

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [ x]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x ]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Describe manual testing done. 

4. **Platforms tested**:

    > * [x ] Windows
    > * [ ] Mac
