### PR TITLE
Fixed wrong URL

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -307,7 +307,7 @@ module.exports = yo.extend({
     this.log(`      3. Open the project in VS Code:\n`);
     this.log(`         ${chalk.bold('code .')}\n`);
     this.log(`         For more information, visit http://code.visualstudio.com.\n`);
-    this.log(`      Please visit https://docs.microsoft.co/office/dev/add-ins for more information about Office Add-ins.\n`);
+    this.log(`      Please visit https://docs.microsoft.com/office/dev/add-ins for more information about Office Add-ins.\n`);
     this.log('----------------------------------------------------------------------------------------------------------\n');
     this._exitProcess();
   },


### PR DESCRIPTION
Replaced `.co` to `.com`

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
The message saying "Please visit https://docs.microsoft.co/office/dev/add-ins for more information about Office Add-ins." had the wrong URL.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Describe manual testing done. 
Ran the generator once

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
