### PR TITLE
Fixed issue where generator-office is not applying the specified proj…

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -273,12 +273,12 @@ module.exports = yo.extend({
         if (projectRepoBranchInfo.repo) {
           await helperMethods.downloadProjectTemplateZipFile(this.destinationPath(), projectRepoBranchInfo.repo, projectRepoBranchInfo.branch);
               
-          // modify manifest guid and DisplayName
-          await modifyManifestFile(`${this.destinationPath()}/manifest.xml`, 'random', `${this.project.name}`);
-
           // Call 'convert-to-single-host' npm script in generated project, passing in host parameter
           const cmdLine = `npm run convert-to-single-host --if-present -- ${_.toLower(this.project.hostInternalName)}`;
           await childProcessExec(cmdLine);
+
+          // modify manifest guid and DisplayName
+          await modifyManifestFile(`${this.destinationPath()}/manifest.xml`, 'random', `${this.project.name}`);
 
           return resolve()
         }

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -26,6 +26,7 @@ const unexpectedManifestFiles = [
 // Test to verify converting a project to a single host
 // for Office-Addin-Taskpane Typescript project using Excel host
 describe('Office-Add-Taskpane-Ts projects', () => {
+    const testProjectName = "TaskpaneProject"
     const expectedFiles = [
         packageJsonFile,
         manifestFile,
@@ -42,7 +43,7 @@ describe('Office-Add-Taskpane-Ts projects', () => {
     let answers = {
         projectType: "taskpane",
         scriptType: "TypeScript",   
-        name: "TaskpaneProject",
+        name: testProjectName,
         host: hosts[0]
     };
 
@@ -80,6 +81,7 @@ describe('Office-Add-Taskpane-Ts projects', () => {
         it('Manifest.xml is updated appropriately', async () => {
             const manifestInfo = await readManifestFile(manifestFile);
             assert.equal(manifestInfo.hosts, "Workbook");
+            assert.equal(manifestInfo.displayName, testProjectName);
         });
     });
 });

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -11,7 +11,6 @@ import { promisify } from "util";
 const hosts = ["excel", "onenote", "outlook", "powerpoint", "project", "word"];
 const manifestFile = "manifest.xml";
 const packageJsonFile = "package.json";
-// For now, all tests will be run with the prerelease option until convert-to-single-host is merged to the yo-office branches
 const readFileAsync = promisify(fs.readFile);
 const unexpectedManifestFiles = [
     'manifest.excel.xml',

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -12,7 +12,6 @@ const hosts = ["excel", "onenote", "outlook", "powerpoint", "project", "word"];
 const manifestFile = "manifest.xml";
 const packageJsonFile = "package.json";
 // For now, all tests will be run with the prerelease option until convert-to-single-host is merged to the yo-office branches
-const prerelease = process.argv.indexOf('--prerelease') > -1 || true;
 const readFileAsync = promisify(fs.readFile);
 const unexpectedManifestFiles = [
     'manifest.excel.xml',
@@ -49,7 +48,7 @@ describe('Office-Add-Taskpane-Ts projects', () => {
 
     describe('Office-Add-Taskpane project', () => {
         before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions(prerelease ? { 'prerelease': true } : {}).withPrompts(answers).on('end', done);
+            helpers.run(path.join(__dirname, '../app')).withPrompts(answers).on('end', done);
         });
 
         it('creates expected files', (done) => {
@@ -111,7 +110,7 @@ describe('Office-Add-Taskpane-Angular-Js project', () => {
 
     describe('Office-Add-Taskpane project', () => {
         before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions(prerelease ? { 'prerelease': true } : {}).withPrompts(answers).on('end', done);
+            helpers.run(path.join(__dirname, '../app')).withPrompts(answers).on('end', done);
         });
 
         it('creates expected files', (done) => {
@@ -172,7 +171,7 @@ describe('Office-Add-Taskpane-React-Ts project', () => {
 
     describe('Office-Add-Taskpane project', () => {
         before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions(prerelease ? { 'prerelease': true } : {}).withPrompts(answers).on('end', done);
+            helpers.run(path.join(__dirname, '../app')).withPrompts(answers).on('end', done);
         });
 
         it('creates expected files', (done) => {


### PR DESCRIPTION
…ect name to the DisplayName field in manifest.xml for the generated project

-Modifying after convert to host, makes sure project name is correctly updated
-Modify manifest after convert-to-single-host
-Adding test to validate project name in manifest

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [ x]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [ x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Stepped through the debugger to ensure changes do what is expected and added unit test to validate manifest project name is updated appropriately

4. **Platforms tested**:

    > * [x ] Windows
    > * [ ] Mac
