### PR TITLE
Issue503

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -41,7 +41,7 @@ module.exports = yo.extend({
   /*  Setup the generator */
   constructor: function () {
         if (parseInt(process.version.slice(1, process.version.indexOf('.'))) % 2 == 1) {
-        this.log(yosay("generator-office currently does not support v13 of Node. Please downgrade to the latest LTS version of Node."));
+        console.log(yosay('generator-office currently does not support ' + process.version + ' of Node. Please switch to the latest LTS version of Node.'));
         this._exitProcess();
     }
     yo.apply(this, arguments);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -40,7 +40,7 @@ const usageDataOptions: usageData.IUsageDataOptions = {
 module.exports = yo.extend({
   /*  Setup the generator */
   constructor: function () {
-    if (process.version.startsWith('v13.')) {
+        if (parseInt(process.version.slice(1, process.version.indexOf('.'))) % 2 == 1) {
         this.log(yosay("generator-office currently does not support v13 of Node. Please downgrade to the latest LTS version of Node."));
         this._exitProcess();
     }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -40,6 +40,10 @@ const usageDataOptions: usageData.IUsageDataOptions = {
 module.exports = yo.extend({
   /*  Setup the generator */
   constructor: function () {
+    if (process.version.startsWith('v13.')) {
+        this.log(yosay("generator-office currently does not support v13 of Node. Please downgrade to the latest LTS version of Node."));
+        this._exitProcess();
+    }
     yo.apply(this, arguments);
 
     this.argument('projectType', { type: String, required: false });

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -41,7 +41,7 @@ module.exports = yo.extend({
   /*  Setup the generator */
   constructor: function () {
         if (parseInt(process.version.slice(1, process.version.indexOf('.'))) % 2 == 1) {
-        console.log(yosay('generator-office currently does not support ' + process.version + ' of Node. Please switch to the latest LTS version of Node.'));
+        console.log(yosay('generator-office currently does not support your version of Node. Please switch to the latest LTS version of Node.'));
         this._exitProcess();
     }
     yo.apply(this, arguments);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -41,7 +41,7 @@ module.exports = yo.extend({
   /*  Setup the generator */
   constructor: function () {
         if (parseInt(process.version.slice(1, process.version.indexOf('.'))) % 2 == 1) {
-        console.log(yosay('generator-office currently does not support your version of Node. Please switch to the latest LTS version of Node.'));
+        console.log(yosay('generator-office does not support your version of Node. Please switch to the latest LTS version of Node.'));
         this._exitProcess();
     }
     yo.apply(this, arguments);


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
Users running a non-LTS version of Node will not be able to run generator-office

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Describe manual testing done. 

Tried to run "yo office" while running v13.6.0. I was successfully blocked from running office-generator and was instructed to switch to the latest LTS version of Node.

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
