### PR TITLE
Add Outlook host for Single-Sign-On

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -13,7 +13,14 @@
                     "branch": "yo-office",
                     "prerelease": "yo-office-prerelease"
                 }
-            }
+            },
+            "supportedHosts": [
+                    "Excel",
+                    "Onenote",
+                    "Outlook",
+                    "Powerpoint",
+                    "Project",
+                    "Word"]
         },
         "angular": {
             "displayname": "Office Add-in Task Pane project using Angular framework",
@@ -28,7 +35,15 @@
                     "branch": "yo-office",
                     "prerelease": "yo-office-prerelease"
                 }
-            }
+            },
+            "supportedHosts": [
+                "Excel",
+                "Onenote",
+                "Outlook",
+                "Powerpoint",
+                "Project",
+                "Word"
+            ]
         },
         "react": {
             "displayname": "Office Add-in Task Pane project using React framework",
@@ -43,7 +58,15 @@
                     "branch": "yo-office",
                     "prerelease": "yo-office-prerelease"
                 }
-            }
+            },
+            "supportedHosts": [
+                "Excel",
+                "Onenote",
+                "Outlook",
+                "Powerpoint",
+                "Project",
+                "Word"
+            ]
         },
         "single-sign-on": {
             "displayname": "Office Add-in Task Pane project supporting single sign-on",
@@ -58,7 +81,13 @@
                     "branch": "yo-office",
                     "prerelease": "yo-office-prerelease"
                 }
-            }
+            },
+            "supportedHosts": [
+                "Excel",
+                "Outlook",
+                "Powerpoint",
+                "Word"
+            ]
         },
         "manifest": {
             "displayname": "Office Add-in project containing the manifest only",
@@ -66,7 +95,15 @@
                 "manifestonly": {
                     "repository": ""
                 }
-            }
+            },
+            "supportedHosts": [
+                "Excel",
+                "Onenote",
+                "Outlook",
+                "Powerpoint",
+                "Project",
+                "Word"
+            ]
         },
         "excel-functions": {
             "displayname": "Excel Custom Functions Add-in project",
@@ -81,33 +118,30 @@
                     "branch": "yo-office",
                     "prerelease": "yo-office-prerelease"
                 }
-            }
+            },
+            "supportedHosts": [
+                "Excel"
+            ]
         }
     },
     "hostTypes": {
         "excel": {
-            "displayname": "Excel",
-            "repository": ""
+            "displayname": "Excel"
         },
         "onenote": {
-            "displayname": "OneNote",
-            "repository": ""
+            "displayname": "OneNote"
         },
         "outlook": {
-            "displayname": "Outlook",
-            "repository": ""
+            "displayname": "Outlook"
         },
         "powerpoint": {
-            "displayname": "PowerPoint",
-            "repository": ""
+            "displayname": "PowerPoint"
         },
         "project": {
-            "displayname": "Project",
-            "repository": ""
+            "displayname": "Project"
         },
         "word": {
-            "displayname": "Word",
-            "repository": ""
+            "displayname": "Word"
         }
     }
 }

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -49,15 +49,11 @@ export default class projectsJsonData {
     return this.m_projectJsonData.projectTypes[_.toLower(projectType)].templates.javascript != undefined && this.m_projectJsonData.projectTypes[_.toLower(projectType)].templates.typescript != undefined;
   }
 
-  getHostTemplateNames(isSsoProject: boolean) {
+  getHostTemplateNames(projectType: string) {
     let hosts: string[] = [];
-    for (let key in this.m_projectJsonData.hostTypes) {
-      if (isSsoProject) {
-        if (key === 'excel' || key === 'word' || key === 'powerpoint') {
-          hosts.push(this.m_projectJsonData.hostTypes[key].displayname);
-        }
-      } else {
-        hosts.push(this.m_projectJsonData.hostTypes[key].displayname);
+    for (let key in this.m_projectJsonData.projectTypes) {
+      if (key === projectType) {
+        hosts = this.m_projectJsonData.projectTypes[key].supportedHosts;
       }
     }
     return hosts;

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -206,7 +206,7 @@ module.exports = yo.extend({
         message: 'Which Office client application would you like to support?',
         type: 'list',
         default: 'Excel',
-        choices: jsonData.getHostTemplateNames(isSsoProject).map(host => ({ name: host, value: host })),
+        choices: jsonData.getHostTemplateNames(answerForProjectType.projectType).map(host => ({ name: host, value: host })),
         when: (this.options.host == null || this.options.host != null && !jsonData.isValidInput(this.options.host, true /* isHostParam */))
           && !isExcelFunctionsProject
       }];


### PR DESCRIPTION
- Make supported hosts data-driven by projectProperties.json

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
This adds Outlook as a suggest host for single-sign-on. This change shouldn't be merged until we make the necessary changes to the Office-Addin-Taskpane-SSO templates and to the office-addin-sso package (separate PRs coming out)

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [x ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
We will need to update SSO documentation to say that Outlook is supported

3. **Validation/testing performed**:

    Describe manual testing done. 
Confirmed new hosts population works
4. **Platforms tested**:

    > * [x ] Windows
    > * [x] Mac
