### PR TITLE
Add build step at end of custom functions project generation

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -356,6 +356,13 @@ module.exports = yo.extend({
       this.log(`         ${chalk.bold('npm start')}\n`);
       this.log(`      4. Open the project in VS Code:\n`);
       this.log(`         ${chalk.bold('code .')}\n`);
+    } else if (this.project.isExcelFunctionsProject) {
+      this.log(`      2. Build your Excel Custom Functions taskpane add-in:\n`);
+      this.log(`         ${chalk.bold('npm run build')}\n`);
+      this.log(`      3. Start the local web server and sideload the add-in:\n`);
+      this.log(`         ${chalk.bold('npm start')}\n`);
+      this.log(`      4. Open the project in VS Code:\n`);
+      this.log(`         ${chalk.bold('code .')}\n`);
     } else {
       this.log(`      2. Start the local web server and sideload the add-in:\n`);
       this.log(`         ${chalk.bold('npm start')}\n`);


### PR DESCRIPTION
- Currently it's not clear to users that they need to build custom functions before running npm start

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x ]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x ]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

local manual testing on Windows

4. **Platforms tested**:

    > * [ ] Windows
    > * [ ] Mac
