### PR TITLE
Fixes issue where postInstallHints wasn't getting called

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,9 +3041,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/src/app/defaults.ts
+++ b/src/app/defaults.ts
@@ -3,6 +3,7 @@ import * as chalk from "chalk";
 export const configurationErrorEventName: string = "configuration-error-generator-office";
 export const copyFilesErrorEventName: string = "copy-files-error-generator-office";
 export const installDependenciesErrorEventName = "install-dependencies-error-generator-office";
+export const postInstallHintsErrorEventName = "post-install-hints-error-generator-office";
 export const promptSelectionstEventName: string = "prompt-selections-generator-office";
 export const promptSelectionsErrorEventName: string = "prompt-selections-error-generator-office";
 export const usageDataProjectName: string = "generator-office";

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -248,20 +248,28 @@ module.exports = class extends yo {
       if (this.options['skip-install']) {
         this.installDependencies({
           npm: false,
-          bower: false,
-          callback: this._postInstallHints.bind(this)
+          bower: false
         });
       }
       else {
         this.installDependencies({
           npm: true,
-          bower: false,
-          callback: this._postInstallHints.bind(this)
+          bower: false
         });
       }
     } catch (err) {
       usageDataObject.reportError(defaults.installDependenciesErrorEventName, new Error('Installation Error: ' + err));
       process.exitCode = 1;
+    }
+  }
+
+  end(): void {
+    if (!this.options['test']) {
+      try {
+        this._postInstallHints();
+      } catch (err) {
+        usageDataObject.reportError(defaults.postInstallHintsErrorEventName, new Error('Exit Error: ' + err));
+      }
     }
   }
 


### PR DESCRIPTION
- The postInstallHints method was no longer getting called due to an apparent change in the way callbacks are handled by yeoman-generator.  This issue presumably surfaced when we upgraded the yeoman-generator version a few months back.  What apparently happens is that the postInstallHints callback is simply ignored following install
- We believe this may be a source of confusion for the SSO template in particular where we give explicit instructions to run "configure-sso" prior to running "npm start"
- The fix is to call postInstallHints in the yeoman-generator "end" method, which is "Called last, cleanup, say good bye, etc"
- Ignoring the call to postInstallHints for test code, since postInstallHints also calls process.exit(), which will cause tests to bail out
- Also update package-lock.json to address vulnerabilities

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x ]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x ]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Did manual test to ensure postInstallHints are now displayed at the end of project generation.  Ran tests locally to ensure they all pass

4. **Platforms tested**:

    > * [ x] Windows
    > * [ ] Mac
