### PR TITLE
Fix post-install hints for non-sideloadable hosts

### DIFF
--- a/src/app/defaults.ts
+++ b/src/app/defaults.ts
@@ -3,6 +3,8 @@ import * as chalk from "chalk";
 export const configurationErrorEventName: string = "configuration-error-generator-office";
 export const copyFilesErrorEventName: string = "copy-files-error-generator-office";
 export const installDependenciesErrorEventName = "install-dependencies-error-generator-office";
+export const networkShareSideloadingSteps: string = "https://docs.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins";
+export const outlookSideloadingSteps = "https://docs.microsoft.com/en-us/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing";
 export const postInstallHintsErrorEventName = "post-install-hints-error-generator-office";
 export const promptSelectionstEventName: string = "prompt-selections-generator-office";
 export const promptSelectionsErrorEventName: string = "prompt-selections-error-generator-office";

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -372,10 +372,30 @@ module.exports = class extends yo {
       this.log(`      4. Open the project in VS Code:\n`);
       this.log(`         ${chalk.bold('code .')}\n`);
     } else {
-      this.log(`      2. Start the local web server and sideload the add-in:\n`);
-      this.log(`         ${chalk.bold('npm start')}\n`);
-      this.log(`      3. Open the project in VS Code:\n`);
-      this.log(`         ${chalk.bold('code .')}\n`);
+      if (this.project.host === "Excel" || this.project.host === "Word" || this.project.host === "Powerpoint") {
+        this.log(`      2. Start the local web server and sideload the add-in:\n`);
+        this.log(`         ${chalk.bold('npm start')}\n`);
+        this.log(`      3. Open the project in VS Code:\n`);
+        this.log(`         ${chalk.bold('code .')}\n`);
+      } else {
+        if (this.project.host === "Outlook") {
+          this.log(`      2. Start the local web server:\n`);
+          this.log(`         ${chalk.bold('npm run dev-server')}\n`);
+          this.log(`      3. Sideload the the add-in:\n`);
+          this.log(`         ${chalk.bold('Follow these instructions:')}`);
+          this.log(`         ${defaults.outlookSideloadingSteps}\n`);
+          this.log(`      4. Open the project in VS Code:\n`);
+          this.log(`         ${chalk.bold('code .')}\n`);
+        } else {
+          this.log(`      2. Start the local web server:\n`);
+          this.log(`         ${chalk.bold('npm run dev-server')}\n`);
+          this.log(`      3. Sideload the the add-in:\n`);
+          this.log(`         ${chalk.bold('Follow these instructions:')}`);
+          this.log(`         ${defaults.networkShareSideloadingSteps}\n`);
+          this.log(`      4. Open the project in VS Code:\n`);
+          this.log(`         ${chalk.bold('code .')}\n`);
+        }
+      }
     }
     this.log(`         For more information, visit http://code.visualstudio.com.\n`);
     this.log(`      Please visit https://docs.microsoft.com/office/dev/add-ins for more information about Office Add-ins.\n`);


### PR DESCRIPTION
There has been confusion amongst users about the post-install hints we provide for non-sideloadable hosts. Given that Outlook, Project and OneNote don't support sideloading, we shouldn't be telling users to simply run "npm start" at the end of project generation since this will attempt to automatically sideload and fail. Rather we should tell users to start the dev-server and then follow the appropriate manual sideloading steps

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
Given that Outlook, Project and OneNote don't support sideloading, we shouldn't be telling users to simply run "npm start" at the end of project generation since this will attempt to automatically sideload and fail. Rather we should tell users to start the dev-server and then follow the appropriate manual sideloading steps

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ x]  Yes
    > * [ ]  No


We should update any documentation that tells users to run "npm start" for non-sideloadable hosts

3. **Validation/testing performed**:

Tested changes against sideloadable and non-sideloadable hosts to ensure post-install hints are correct


4. **Platforms tested**:

    > * [ x] Windows
    > * [ ] Mac
