### PR TITLE
Add shared runtime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ react | Task Pane add-in using the React framework
 excel-functions | Task Pane add-in with Excel Custom Functions
 single-sign-on | Taskpane add-in supporting single-sign-on
 manifest | Manifest and related files for an Office Add-in
+shared-runtime | Task Pane add-in with Excel Custom Functions and Shared Runtime
 
 - Type: String
 - Optional

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -122,6 +122,24 @@
             "supportedHosts": [
                 "Excel"
             ]
+        },
+        "shared-runtime": {
+            "displayname": "Excel Custom Functions Shared Runtime Add-in project",
+            "templates": {
+                "javascript": {
+                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
+                    "branch": "shared-runtime-yo-office",
+                    "prerelease": "shared-runtime-yo-office-prerelease"
+                },
+                "typescript": {
+                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
+                    "branch": "shared-runtime-yo-office",
+                    "prerelease": "shared-runtime-yo-office-prerelease"
+                }
+            },
+            "supportedHosts": [
+                "Excel"
+            ]
         }
     },
     "hostTypes": {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -17,6 +17,7 @@ const yo = require("yeoman-generator");
 
 const childProcessExec = promisify(childProcess.exec);
 const excelCustomFunctions = `excel-functions`;
+const sharedRuntime = 'shared-runtime';
 let isSsoProject = false;
 const javascript = `JavaScript`;
 let language;
@@ -163,9 +164,10 @@ module.exports = class extends yo {
         isManifestProject = true;
       }
 
-      /* Set isExcelFunctionsProject to true if ExcelFunctions project type selected from prompt or Excel Functions was specified via the command prompt */
-      if ((answerForProjectType.projectType != null && answerForProjectType.projectType) === excelCustomFunctions
-        || (this.options.projectType != null && _.toLower(this.options.projectType) === excelCustomFunctions)) {
+      /* Set isExcelFunctionsProject to true if ExcelFunctions or Shared Rumtime project type selected from prompt or Excel Functions or
+       *Shared Rumtime was specified via the command prompt */
+      if ((answerForProjectType.projectType != null && answerForProjectType.projectType) === excelCustomFunctions || sharedRuntime
+        || (this.options.projectType != null && _.toLower(this.options.projectType) === excelCustomFunctions || sharedRuntime)) {
         isExcelFunctionsProject = true;
       }
 
@@ -296,7 +298,7 @@ module.exports = class extends yo {
       this.project.projectInternalName = _.kebabCase(this.project.name);
       this.project.projectDisplayName = this.project.name;
       this.project.projectId = uuid();
-      if (this.project.projectType === excelCustomFunctions) {
+      if (this.project.projectType === excelCustomFunctions || sharedRuntime) {
         this.project.host = 'Excel';
         this.project.hostInternalName = 'Excel';
       }
@@ -323,7 +325,7 @@ module.exports = class extends yo {
 
         this._projectCreationMessage();
 
-        // Copy project template files from project repository (currently only custom functions has its own separate repo)
+        // Copy project template files from project repository
         if (projectRepoBranchInfo.repo) {
           await helperMethods.downloadProjectTemplateZipFile(this.destinationPath(), projectRepoBranchInfo.repo, projectRepoBranchInfo.branch);
 
@@ -365,7 +367,11 @@ module.exports = class extends yo {
       this.log(`      4. Open the project in VS Code:\n`);
       this.log(`         ${chalk.bold('code .')}\n`);
     } else if (this.project.isExcelFunctionsProject) {
-      this.log(`      2. Build your Excel Custom Functions taskpane add-in:\n`);
+      if (this.project.projectType === excelCustomFunctions) {
+        this.log(`      2. Build your Excel Custom Functions taskpane add-in:\n`);
+      } else {
+        this.log(`      2. Build your Excel Custom Functions Shared Runtime taskpane add-in:\n`);
+      }
       this.log(`         ${chalk.bold('npm run build')}\n`);
       this.log(`      3. Start the local web server and sideload the add-in:\n`);
       this.log(`         ${chalk.bold('npm start')}\n`);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -164,10 +164,11 @@ module.exports = class extends yo {
         isManifestProject = true;
       }
 
-      /* Set isExcelFunctionsProject to true if ExcelFunctions or Shared Rumtime project type selected from prompt or Excel Functions or
-       *Shared Rumtime was specified via the command prompt */
-      if ((answerForProjectType.projectType != null && answerForProjectType.projectType) === excelCustomFunctions || sharedRuntime
-        || (this.options.projectType != null && _.toLower(this.options.projectType) === excelCustomFunctions || sharedRuntime)) {
+      /* Set isExcelFunctionsProject to true if Excel Functions or Shared Rumtime project type selected from prompt or via the command prompt */
+      if ((answerForProjectType.projectType != null && answerForProjectType.projectType) === excelCustomFunctions
+        || (this.options.projectType != null && _.toLower(this.options.projectType) === excelCustomFunctions)
+        || (answerForProjectType.projectType != null && answerForProjectType.projectType) === sharedRuntime
+        || (this.options.projectType != null && _.toLower(this.options.projectType) === sharedRuntime)){
         isExcelFunctionsProject = true;
       }
 
@@ -298,7 +299,7 @@ module.exports = class extends yo {
       this.project.projectInternalName = _.kebabCase(this.project.name);
       this.project.projectDisplayName = this.project.name;
       this.project.projectId = uuid();
-      if (this.project.projectType === excelCustomFunctions || sharedRuntime) {
+      if (this.project.projectType === excelCustomFunctions || this.project.projectType === sharedRuntime) {
         this.project.host = 'Excel';
         this.project.hostInternalName = 'Excel';
       }


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [X ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
There will be an additional project type to select from - the Shared Runtime project type

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ z]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
We will need to update any documentation that refers to creating a project with Yo Office. Also we will need to update any existing Shared Runtime documentation to explain that Yo Office can now be used for generating a Shared Runtime project

3. **Validation/testing performed**:

    Tested on Windows. Testing on Mac to follow

4. **Platforms tested**:

    > * [ x] Windows
    > * [ ] Mac
