### PR TITLE
Require NodeJS 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 node_js:
   - 'stable'
   - 'lts/*'
-  - 12
+  - 14
 before_script: "npm run build"
 script: "npm run test"
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
   - node_modules
 node_js:
   - 'stable'
+  - 'lts/*'
+  - 12
 before_script: "npm run build"
 script: "npm run test"
 os:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "mocha --timeout 0 -r ts-node/register generators/test/**.js"
   },
   "engines": {
-    "node": ">6.9.0"
+    "node": ">=12"
   },
   "homepage": "https://github.com/officedev/generator-office",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "mocha --timeout 0 -r ts-node/register generators/test/**.js"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "homepage": "https://github.com/officedev/generator-office",
   "license": "MIT",


### PR DESCRIPTION
The **package.json** will require at least NodeJS v12 and Travis builds will test with v12, LTS and the current NodeJS releases.

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x]  No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    No, the documentation and tutorials already require to use NodeJS LTS (v14).


3. **Validation/testing performed**:

    Travis CI build and local `npm test`

4. **Platforms tested**:

    > * [x] Windows
    > * [x] Mac
