### PR TITLE
Add yeoman legacy install prototype

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -15,6 +15,11 @@ import { v4 as uuidv4 } from 'uuid';
 import * as yosay from 'yosay';
 const yo = require("yeoman-generator");
 
+// Workaround for generator-office breaking change (v4 => v5)
+// If we can figure out how to get the new packageManagerInstallTask to work 
+// with downloaded package.json then we won't need this or the installDependencies calls
+-_.extend(yo.prototype, require('yeoman-generator/lib/actions/install'));
+
 const childProcessExec = promisify(childProcess.exec);
 const excelCustomFunctions = `excel-functions`;
 let isSsoProject = false;


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Ran installer locally

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac


When we updated to yeoman-generator v5 we took on a breaking change . . . the call to installDependencies was removed and so 'npm install' was not getting called.  The new support for installing dependencies seems to require yeoman modification to the package.json file for the installer to get called (no documentation or examples for the updates).  Doing this import gets us the legacy call back until we can figure out how to use the new methodology to trigger 'npm install'