### PR TITLE
Fix resolve manifest operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-office",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -816,14 +816,14 @@
       }
     },
     "applicationinsights": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.5.tgz",
-      "integrity": "sha512-sl3rNhVnQOG4ecJNKh7dlAZOc/DLfZTRs1F6PO3nb969AsnVg7C4xWRoybI9+mbtqyPR4NA2JbG4bHJOGP3j+A==",
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
+      "integrity": "sha512-ZLDA7mShh4mP2Z/HlFolmvhBPX1LfnbIWXrselyYVA7EKjHhri1fZzpu2EiWAmfbRxNBY6fRjoPJWbx5giKy4A==",
       "requires": {
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.4"
+        "diagnostic-channel": "0.3.1",
+        "diagnostic-channel-publishers": "0.4.4"
       }
     },
     "aproba": {
@@ -1626,9 +1626,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "common-ancestor-path": {
       "version": "1.0.1",
@@ -2020,17 +2020,17 @@
       }
     },
     "diagnostic-channel": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+      "integrity": "sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==",
       "requires": {
         "semver": "^5.3.0"
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
-      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz",
+      "integrity": "sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ=="
     },
     "diff": {
       "version": "4.0.2",
@@ -4443,8 +4443,7 @@
     "npm-normalize-package-bin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "dev": true
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "npm-package-arg": {
       "version": "8.1.5",
@@ -4646,33 +4645,27 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.17.tgz",
-      "integrity": "sha512-Q8ldxcxPF69/W4TprG9u3M2zFigQR/bTF3CJDb/BQPgMIMZIOSHhOd1jUNDCufEhwm8uhuywIOhxbemahweFoQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.2.2.tgz",
+      "integrity": "sha512-+j6TTkxK2C/IyZM5B/eTEA4o6MKszqOOryzGgFTZEArDDUp3a90piXue3GFgpTkOYR8gNAt+zQEgFZxpsdPzcQ==",
       "requires": {
-        "commander": "^6.2.0",
-        "node-fetch": "^2.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
-        }
+        "commander": "^6.2.1",
+        "node-fetch": "^2.6.1",
+        "read-package-json-fast": "^2.0.2"
       }
     },
     "office-addin-manifest": {
-      "version": "1.5.16",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.16.tgz",
-      "integrity": "sha512-s9T/2oHEYAkosuns143THGyDyoxcpgRowrkRF4qQJFqYjU2ruklQw+FujmsFLmOxvGGcgXrk6XeoEwR3vD3QAw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.6.2.tgz",
+      "integrity": "sha512-mXqrLTU6nwOqFIbwqV3QUZuhYZGbSbk0S1QobtCeeCMWCJEk3Ypg2XeNuZR9W3CVzhy5w87C0muW2/PvkhXGfw==",
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.0.17",
-        "office-addin-usage-data": "^1.0.23",
+        "office-addin-cli": "^1.2.2",
+        "office-addin-usage-data": "^1.3.2",
         "path": "^0.12.7",
-        "uuid": "^3.4.0",
+        "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
       },
       "dependencies": {
@@ -4707,11 +4700,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
-        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4724,34 +4712,18 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
     "office-addin-usage-data": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.1.4.tgz",
-      "integrity": "sha512-k2jhtK5lVdrgcXmtnf5KJxtw3ZeUwEZGYcV6+j5ZaZSNbtDxppC+s4j28j4Lhi0D66QSWepBw1d36j9Acqwdpw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.3.2.tgz",
+      "integrity": "sha512-ShNiXBTVBSatj5gyHjLj3nxLoCUMZrqE9xnEfe+z3csYpbIlUwWswMZBq0Mnom37ShmLJsmCt0N8QIwliL2N+w==",
       "requires": {
         "applicationinsights": "^1.7.3",
-        "commander": "^2.20.3",
-        "office-addin-cli": "^0.2.8",
+        "commander": "^6.2.0",
+        "office-addin-cli": "^1.2.2",
         "readline-sync": "^1.4.9"
-      },
-      "dependencies": {
-        "office-addin-cli": {
-          "version": "0.2.18",
-          "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.18.tgz",
-          "integrity": "sha512-N6fGjjbnGhCa/XDhx76XFLKzrz2oce1aCzBtlPvIbF2VcHyvmIkHsI8PlH9B8kP/zLRQz5nSGjFidh+5bwOvmw==",
-          "requires": {
-            "commander": "^2.19.0",
-            "node-fetch": "^2.3.0"
-          }
-        }
       }
     },
     "once": {
@@ -5290,7 +5262,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.2.tgz",
       "integrity": "sha512-5fyFUyO9B799foVk4n6ylcoAktG/FbE3jwRKxvwaeSrIunaoMc0u81dzXxjeAFKOce7O5KncdfwpGvvs6r5PsQ==",
-      "dev": true,
       "requires": {
         "json-parse-even-better-errors": "^2.3.0",
         "npm-normalize-package-bin": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "dependencies": {
     "chalk": "^4.0.0",
     "lodash": "^4.17.21",
-    "office-addin-manifest": "^1.5.16",
-    "office-addin-usage-data": "^1.0.23",
+    "office-addin-manifest": "^1.6.2",
+    "office-addin-usage-data": "^1.3.2",
     "opn": "^6.0.0",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-office",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "Yeoman generator for creating Microsoft Office projects using any text editor.",
   "repository": {
     "type": "git",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -7,7 +7,7 @@ import * as chalk from 'chalk';
 import * as childProcess from "child_process";
 import * as defaults from "./defaults";
 import { helperMethods } from './helpers/helperMethods';
-import { modifyManifestFile } from 'office-addin-manifest';
+import { OfficeAddinManifest } from 'office-addin-manifest';
 import projectsJsonData from './config/projectsJsonData';
 import { promisify } from "util";
 import * as usageData from "office-addin-usage-data";
@@ -339,7 +339,7 @@ module.exports = class extends yo {
           await childProcessExec(cmdLine);
 
           // modify manifest guid and DisplayName
-          await modifyManifestFile(`${this.destinationPath()}/manifest.xml`, 'random', `${this.project.name}`);
+          await OfficeAddinManifest.modifyManifestFile(`${this.destinationPath()}/manifest.xml`, 'random', `${this.project.name}`);
 
           return resolve()
         }

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -5,7 +5,7 @@
 import * as assert from 'yeoman-assert';
 import * as fs from "fs";
 import * as helpers from 'yeoman-test';
-import { readManifestFile } from "office-addin-manifest";
+import { OfficeAddinManifest } from "office-addin-manifest";
 import * as path from 'path';
 import { promisify } from "util";
 const hosts = ["excel", "onenote", "outlook", "powerpoint", "project", "word"];
@@ -77,7 +77,7 @@ describe('Office-Add-Taskpane-Ts projects', () => {
 
     describe('Manifest.xml is updated appropriately', () => {
         it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await readManifestFile(manifestFile);
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
             assert.equal(manifestInfo.hosts, "Workbook");
             assert.equal(manifestInfo.displayName, testProjectName);
         });
@@ -139,7 +139,7 @@ describe('Office-Add-Taskpane-Angular-Js project', () => {
 
     describe('Manifest.xml is updated appropriately', () => {
         it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await readManifestFile(manifestFile);
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
             assert.equal(manifestInfo.hosts, "Document");
         });
     });
@@ -200,7 +200,7 @@ describe('Office-Add-Taskpane-React-Ts project', () => {
 
     describe('Manifest.xml is updated appropriately', () => {
         it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await readManifestFile(manifestFile);
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
             assert.equal(manifestInfo.hosts, "Presentation");
         });
     });


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Update dependent packages and run yo office with debugger

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac


The new package of office-addin-manifest moved methods to namespaces.  This project need to update the references to those methods to include the namespace.