### PR TITLE
Making custom functions default to shared runtime

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -106,17 +106,17 @@
             ]
         },
         "excel-functions": {
-            "displayname": "Excel Custom Functions Add-in project",
+            "displayname": "Excel Custom Functions Shared Runtime Add-in project",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "shared-runtime-yo-office",
+                    "prerelease": "shared-runtime-yo-office-prerelease"
                 },
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "shared-runtime-yo-office",
+                    "prerelease": "shared-runtime-yo-office-prerelease"
                 }
             },
             "supportedHosts": [


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [X]  Yes
    > * [ ]  No

Make CF project now use by default the shared runtime.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [X]  Yes
    > * [ ]  No

Will need to contact the documentation team to update their shared runtime tutorial, as it is not needed anymore.


3. **Validation/testing performed**:

Tested that when selecting this new option and downloading the template from the right place.

4. **Platforms tested**:

    > * [X] Windows
    > * [ ] Mac
