### PR TITLE
Changing option name

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -124,7 +124,7 @@
             ]
         },
         "json-based-manifest": {
-            "displayname": "[Preview] Json Based Add-in Project",
+            "displayname": "[Preview] Outlook Add-in with JSON manifest",
             "templates": {
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -124,7 +124,7 @@
             ]
         },
         "json-based-manifest": {
-            "displayname": "[Preview] Outlook Add-in with JSON manifest",
+            "displayname": "Outlook Add-in with Teams Manifest (Developer preview)",
             "templates": {
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",


### PR DESCRIPTION
Changing the option name for `JSON` manifest as recommended by @Rick-Kirkham 