### PR TITLE
Fixing ts option

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -196,9 +196,6 @@ module.exports = class extends yo {
         }
       ];
       const answerForScriptType = await this.prompt(askForScriptType);
-      if (!answerForScriptType.scriptType && !this.options.js && !this.options.ts) {
-        answerForScriptType.scriptType = getSupportedScriptTypes[0];
-      }
 
       /* askforName will be triggered if no project name was specified via command line Name argument */
       const askForName = [{
@@ -223,9 +220,6 @@ module.exports = class extends yo {
           && jsonData.getHostTemplateNames(projectType).length > 1
       }];
       const answerForHost = await this.prompt(askForHost);
-      if (!answerForHost.host && !this.options.host) {
-        answerForHost.host = jsonData.getHostTemplateNames(projectType)[0];
-      }
       const endForHost = (new Date()).getTime();
       const durationForHost = (endForHost - startForHost) / 1000;
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -196,7 +196,7 @@ module.exports = class extends yo {
         }
       ];
       const answerForScriptType = await this.prompt(askForScriptType);
-      if (!answerForScriptType.scriptType) {
+      if (!answerForScriptType.scriptType && !this.options.ts) {
         answerForScriptType.scriptType = getSupportedScriptTypes[0];
       }
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -196,7 +196,7 @@ module.exports = class extends yo {
         }
       ];
       const answerForScriptType = await this.prompt(askForScriptType);
-      if (!answerForScriptType.scriptType && !this.options.ts) {
+      if (!answerForScriptType.scriptType && !this.options.js && !this.options.ts) {
         answerForScriptType.scriptType = getSupportedScriptTypes[0];
       }
 
@@ -223,7 +223,7 @@ module.exports = class extends yo {
           && jsonData.getHostTemplateNames(projectType).length > 1
       }];
       const answerForHost = await this.prompt(askForHost);
-      if (!answerForHost.host) {
+      if (!answerForHost.host && !this.options.host) {
         answerForHost.host = jsonData.getHostTemplateNames(projectType)[0];
       }
       const endForHost = (new Date()).getTime();


### PR DESCRIPTION
This PR makes the `--ts` option work again and makes typescript be chosen. It had a bug that the option was getting ignored and the generated project was javascript.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

Tested that the `yo office --ts` options are now creating a typescript project.

4. **Platforms tested**:

    > * [X] Windows
    > * [ ] Mac
