### PR TITLE
Add note that SSO is not for production purposes

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -72,7 +72,7 @@
             ]
         },
         "single-sign-on": {
-            "displayname": "Office Add-in Task Pane project supporting single sign-on",
+            "displayname": "Office Add-in Task Pane project with single sign-on (not for production)",
             "manifestPath": "manifest.xml",
             "templates": {
                 "javascript": {


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.

The name of the SSO option is modified to note it is not for use in production.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [x ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
The SSO quickstart will need to be updated. It will also have some information indicating developers should only use this template for studying SSO, and that it does not support deployment to Azure or other cloud services.

3. **Validation/testing performed**:

    Describe manual testing done. 

None (just did a text change).

4. **Platforms tested**:

    > * [ ] Windows
    > * [ ] Mac
