### PR TITLE
Update template options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,11 +14,11 @@ This [Yeoman](http://yeoman.io) generator creates a Node.js [Office Add-in](http
 
 In addition you can use it to create add-ins that use single sign-on or Excel custom functions.
 
-Like other Yeoman generators, this generator simply creates the scaffolding of files for your Office Add-in project. You can choose to create Office Add-in projects using plain HTML, CSS & JavaScript, or using Angular or React, and can choose between JavaScript and Typescript as well.
+Like other Yeoman generators, this generator simply creates the scaffolding of files for your Office Add-in project. You can choose to create Office Add-in projects using plain HTML, CSS & JavaScript, or using React, and can choose between JavaScript and Typescript as well.
 
 > **Note:** While you can also use [Visual Studio](https://visualstudio.microsoft.com/vs) to create Office Add-in projects, the Yeoman generator provides more options in terms of the types of projects you can create. For example:
 >
-> - The Yeoman generator can create Office Add-in projects that use plain HTML, CSS & JavaScript, or React, or Angular; whereas Visual Studio can only create Office Add-in projects that use plain HTML, CSS & JavaScript.
+> - The Yeoman generator can create Office Add-in projects that use plain HTML, CSS & JavaScript, or React; whereas Visual Studio can only create Office Add-in projects that use plain HTML, CSS & JavaScript.
 > - The Yeoman generator can create Office Add-ins projects that use either JavaScript or TypeScript; whereas Visual Studio only creates JavaScript projects which you would need to convert manually if you want to use TypeScript.
 > - The Yeoman generator can create add-ins for Excel, OneNote, Outlook, PowerPoint, Project, and Word; whereas Visual Studio can only create add-ins for Excel, Outlook, PowerPoint, and Word.
 
@@ -61,7 +61,6 @@ Specifies the project type to create.
 Project Type | Description
 ----------- | ------------------------
 taskpane | Task Pane add-in using HTML
-angular | Task Pane add-in using the Angular framework
 react | Task Pane add-in using the React framework
 excel-functions | Task Pane add-in with Excel Custom Functions
 single-sign-on | Taskpane add-in supporting single-sign-on

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -47,30 +47,6 @@
                 "Word"
             ]
         },
-        "angular": {
-            "displayname": "Office Add-in Task Pane project using Angular framework",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-Angular-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                },
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-Angular",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                }
-            },
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
-        },
         "excel-functions-shared": {
             "displayname": "Excel Custom Functions using a Shared Runtime",
             "manifestPath": "manifest.xml",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -422,7 +422,6 @@ module.exports = class extends yo {
     this.log(`\nYo Office ${chalk.bgGreen('Arguments')} and ${chalk.bgMagenta('Options.')}\n`);
     this.log(`NOTE: ${chalk.bgGreen('Arguments')} must be specified in the order below, and ${chalk.bgMagenta('Options')} must follow ${chalk.bgGreen('Arguments')}.\n`);
     this.log(`  ${chalk.bgGreen('projectType')}:Specifies the type of project to create. Valid project types include:`);
-    this.log(`    ${chalk.yellow('angular:')}  Creates an Office add-in using Angular framework.`);
     this.log(`    ${chalk.yellow('excel-functions-shared:')} Creates an Office add-in for Excel custom functions using a Shared Runtime.`);
     this.log(`    ${chalk.yellow('excel-functions:')} Creates an Office add-in for Excel custom functions using a JavaScript-only Runtime.`);
     this.log(`    ${chalk.yellow('jquery:')} Creates an Office add-in using Jquery framework.`);

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -86,67 +86,6 @@ describe('Office-Add-Taskpane-Ts projects', () => {
 });
 
 // Test to verify converting a project to a single host
-// for Angular JavaScript project using Word host
-describe('Office-Add-Taskpane-Angular-Js project', () => {
-    const expectedFiles = [
-        packageJsonFile,
-        manifestFile,
-        'src/taskpane/app/app.component.js',
-    ]
-    const unexpectedFiles = [
-        'src/taskpane/app/excel.app.component.js',
-        'src/taskpane/app/onenote.app.component.js',
-        'src/taskpane/app/outlook.app.component.js',
-        'src/taskpane/app/powerpoint.app.component.js',
-        'src/taskpane/app/project.app.component.js',
-        'src/taskpane/app/word.app.component.js',
-    ]
-    const answers = {
-        projectType: "angular",
-        scriptType: "JavaScript",
-        name: "AngularProject",
-        host: hosts[5]
-    };
-
-    describe('Office-Add-Taskpane project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-        });
-
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
-    });
-
-    describe('Package.json is updated appropriately', () => {
-        it('Package.json is updated properly', async () => {
-            const data: string = await readFileAsync(packageJsonFile, 'utf8');
-            const content = JSON.parse(data);
-            assert.equal(content.config["app_to_debug"], hosts[5]);
-
-            // Verify host-specific sideload and unload sripts have been removed
-            let unexexpectedScriptsFound = false;
-            Object.keys(content.scripts).forEach(function (key) {
-                if (key.includes("sideload:") || key.includes("unload:")) {
-                    unexexpectedScriptsFound = true;
-                }
-            });
-            assert.equal(unexexpectedScriptsFound, false);
-        });
-    });
-
-    describe('Manifest.xml is updated appropriately', () => {
-        it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
-            assert.equal(manifestInfo.hosts, "Document");
-        });
-    });
-});
-
-// Test to verify converting a project to a single host
 // for React Typescript project using PowerPoint host
 describe('Office-Add-Taskpane-React-Ts project', () => {
     const expectedFiles = [


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

Removing the option to create an Angular project using the 'yo office' command.
---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
There is one less option for them to pick from.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [x]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.
We need to indicate that Angular is no longer a supported template.  Instructions on how to add add-in functionality to a random framework would be nice to have.

3. **Validation/testing performed**:
Ran automated tests (had to remove the test that looked for Angular)

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
