### PR TITLE
Removed the 'prerelease' designated branches and defaulted to "master" branch

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -6,13 +6,11 @@
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 },
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 }
             },
             "supportedHosts": [
@@ -29,13 +27,11 @@
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-React-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 },
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-React",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 }
             },
             "supportedHosts": [
@@ -54,12 +50,12 @@
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
                     "branch": "shared-runtime-yo-office",
-                    "prerelease": "shared-runtime-yo-office-prerelease"
+                    "prerelease": "shared-runtime"
                 },
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
                     "branch": "shared-runtime-yo-office",
-                    "prerelease": "shared-runtime-yo-office-prerelease"
+                    "prerelease": "shared-runtime"
                 }
             },
             "supportedHosts": [
@@ -72,13 +68,11 @@
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 },
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 }
             },
             "supportedHosts": [
@@ -91,13 +85,11 @@
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-SSO-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 },
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-Taskpane-SSO",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
+                    "branch": "yo-office"
                 }
             },
             "supportedHosts": [
@@ -114,7 +106,7 @@
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",
                     "branch": "json-preview-yo-office",
-                    "prerelease": "json-preview-yo-office-prerelease"
+                    "prerelease": "json-preview"
                 }
             },
             "supportedHosts": [

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -109,7 +109,12 @@ export default class projectsJsonData {
         }
         else {
           if (prerelease) {
-            return this.m_projectJsonData.projectTypes[key].templates[scriptType].prerelease
+            if (this.m_projectJsonData.projectTypes[key].templates[scriptType].prerelease) {
+              return this.m_projectJsonData.projectTypes[key].templates[scriptType].prerelease
+            }
+            else {
+              return "master";
+            }
           } else {
             return this.m_projectJsonData.projectTypes[key].templates[scriptType].branch;
           }

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -85,6 +85,68 @@ describe('Office-Add-Taskpane-Ts projects', () => {
     });
 });
 
+// for Office-Addin-Taskpane Typescript project using Excel host
+describe('Office-Add-Taskpane-Ts prerelease projects', () => {
+    const testProjectName = "TaskpaneProject"
+    const expectedFiles = [
+        packageJsonFile,
+        manifestFile,
+        'src/taskpane/taskpane.ts',
+    ]
+    const unexpectedFiles = [
+        'src/taskpane/excel.ts',
+        'src/taskpane/onenote.ts',
+        'src/taskpane/outlook.ts',
+        'src/taskpane/powerpoint.ts',
+        'src/taskpane/project.ts',
+        'src/taskpane/word.ts'
+    ]
+    const answers = {
+        projectType: "taskpane",
+        scriptType: "TypeScript",
+        name: testProjectName,
+        host: hosts[0]
+    };
+
+     describe('Office-Add-Taskpane prerelease project', () => {
+        before((done) => {
+            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
+        });
+
+        it('creates expected files', (done) => {
+            assert.file(expectedFiles);
+            assert.noFile(unexpectedFiles);
+            assert.noFile(unexpectedManifestFiles);
+            done();
+        });
+    });
+
+    describe('Package.json is updated appropriately', () => {
+        it('Package.json is updated properly', async () => {
+            const data: string = await readFileAsync(packageJsonFile, 'utf8');
+            const content = JSON.parse(data);
+            assert.equal(content.config["app_to_debug"], hosts[0]);
+
+            // Verify host-specific sideload and unload sripts have been removed
+            let unexexpectedScriptsFound = false;
+            Object.keys(content.scripts).forEach(function (key) {
+                if (key.includes("sideload:") || key.includes("unload:")) {
+                    unexexpectedScriptsFound = true;
+                }
+            });
+            assert.equal(unexexpectedScriptsFound, false);
+        });
+    });
+
+    describe('Manifest.xml is updated appropriately', () => {
+        it('Manifest.xml is updated appropriately', async () => {
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
+            assert.equal(manifestInfo.hosts, "Workbook");
+            assert.equal(manifestInfo.displayName, testProjectName);
+        });
+    });
+});
+
 // Test to verify converting a project to a single host
 // for React Typescript project using PowerPoint host
 describe('Office-Add-Taskpane-React-Ts project', () => {


### PR DESCRIPTION
Remove the separate 'prerelease' branches from the template designations and add a default branch of "master" for the 'prerelease' options.  Also added a 'prerelease' test.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

    Used VS Code debugger to verify correct code paths.  Ran independently of debugger.  Added test for "prerelease" flag

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
