### PR TITLE
[FIX] Fix the hang arrow key in script type selection when the UsageDataPrompt is no needed to show

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -113,19 +113,18 @@ module.exports = class extends yo {
   /* Prompt user for project options */
   async prompting(): Promise<void> {
     try {
-      const promptForUsageData = [
-        {
-          name: 'usageDataPromptAnswer',
-          message: usageDataOptions.promptQuestion,
-          type: 'list',
-          default: 'Continue',
-          choices: ['Continue', 'Exit'],
-          when: usageData.needToPromptForUsageData(usageDataOptions.groupName)
-        }
-      ];
-      const answerForUsageDataPrompt = await this.prompt(promptForUsageData);
-      if (answerForUsageDataPrompt.usageDataPromptAnswer) {
-        if (answerForUsageDataPrompt.usageDataPromptAnswer === 'Continue') {
+      if (usageData.needToPromptForUsageData(usageDataOptions.groupName)) {
+        const promptForUsageData = [
+          {
+            name: 'usageDataPromptAnswer',
+            message: usageDataOptions.promptQuestion,
+            type: 'list',
+            default: 'Continue',
+            choices: ['Continue', 'Exit'],
+          }
+        ];
+        const answerForUsageDataPrompt = await this.prompt(promptForUsageData);
+        if (answerForUsageDataPrompt?.usageDataPromptAnswer === 'Continue') {
           usageDataOptions.usageDataLevel = usageData.UsageDataLevel.on;
         } else {
           process.exit();


### PR DESCRIPTION
[FIX] Fix the hang arrow key in script type selection when the UsageDataPrompt is no needed to show

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    When `promptForUsageData` is needed, the prompt show and user can select as expected. But when the `promptForUsageData` is no needed to show, the user's arrow key will be hang in script type selection step. After some investigation, this issue should be related to Inquirer.js (Inquirer.js is used by Yeoman) v8's `when` option api. This PR move the condition judge out from `prompt()` and fix the arrow key hang issue. This will make the ux more fluently.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No


3. **Validation/testing performed**:

    Manual testing: `npm run build && npm link`, then `yo office` works well. Delete `office-addin-usage-data.json` in user's folder, `yo office` works well.

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
