### PR TITLE
Combine xml and json template repo references

### DIFF
--- a/.azure-devops/test.yml
+++ b/.azure-devops/test.yml
@@ -3,7 +3,8 @@ steps:
     inputs:
       script: |
         echo Running Tests
-            
+        
+        npm install office-addin-manifest
         npm run test
             
         echo Done running tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-office",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-office",
-      "version": "1.9.7",
+      "version": "1.9.8",
       "license": "MIT",
       "dependencies": {
         "axios": "1.6.0",
@@ -3338,9 +3338,10 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "devOptional": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-office",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Yeoman generator for creating Microsoft Office projects using any text editor.",
   "repository": {
     "type": "git",

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -2,7 +2,6 @@
     "projectTypes": {
         "taskpane": {
             "displayname": "Office Add-in Task Pane project",
-            "manifestPath": "manifest.xml",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-JS",
@@ -13,17 +12,21 @@
                     "branch": "yo-office"
                 }
             },
+            "supportedManifestTypes": [
+                "xml",
+                "json"
+            ],
             "supportedHosts": [
-                    "Excel",
-                    "Onenote",
-                    "Outlook",
-                    "Powerpoint",
-                    "Project",
-                    "Word"]
+                "Excel",
+                "Onenote",
+                "Outlook",
+                "Powerpoint",
+                "Project",
+                "Word"
+            ]
         },
         "react": {
             "displayname": "Office Add-in Task Pane project using React framework",
-            "manifestPath": "manifest.xml",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-React-JS",
@@ -34,6 +37,9 @@
                     "branch": "yo-office"
                 }
             },
+            "supportedManifestTypes": [
+                "xml"
+            ],
             "supportedHosts": [
                 "Excel",
                 "Onenote",
@@ -45,7 +51,6 @@
         },
         "excel-functions-shared": {
             "displayname": "Excel Custom Functions using a Shared Runtime",
-            "manifestPath": "manifest.xml",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
@@ -58,13 +63,15 @@
                     "prerelease": "shared-runtime"
                 }
             },
+            "supportedManifestTypes": [
+                "xml"
+            ],
             "supportedHosts": [
                 "Excel"
             ]
         },
         "excel-functions": {
             "displayname": "Excel Custom Functions using a JavaScript-only Runtime",
-            "manifestPath": "manifest.xml",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
@@ -75,13 +82,15 @@
                     "branch": "yo-office"
                 }
             },
+            "supportedManifestTypes": [
+                "xml"
+            ],
             "supportedHosts": [
                 "Excel"
             ]
         },
         "single-sign-on": {
             "displayname": "Office Add-in Task Pane project supporting single sign-on",
-            "manifestPath": "manifest.xml",
             "templates": {
                 "javascript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-SSO-JS",
@@ -92,6 +101,9 @@
                     "branch": "yo-office"
                 }
             },
+            "supportedManifestTypes": [
+                "xml"
+            ],
             "supportedHosts": [
                 "Excel",
                 "Outlook",
@@ -99,28 +111,16 @@
                 "Word"
             ]
         },
-        "unified-manifest": {
-            "displayname": "Outlook Add-in with unified manifest for Microsoft 365 (preview)",
-            "manifestPath": "manifest.json",
-            "templates": {
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",
-                    "branch": "json-preview-yo-office",
-                    "prerelease": "json-preview"
-                }
-            },
-            "supportedHosts": [
-                "Outlook"
-            ]
-        },
         "manifest": {
             "displayname": "Office Add-in project containing the manifest only",
-            "manifestPath": "manifest.xml",
             "templates": {
                 "manifestonly": {
                     "repository": ""
                 }
             },
+            "supportedManifestTypes": [
+                "xml"
+            ],
             "supportedHosts": [
                 "Excel",
                 "Onenote",
@@ -149,6 +149,14 @@
         },
         "word": {
             "displayname": "Word"
+        }
+    },
+    "manifestTypes": {
+        "xml": {
+            "displayname": "XML Manifest"
+        },
+        "json": {
+            "displayname": "Unified manifest for Microsoft 365"
         }
     }
 }

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -10,23 +10,31 @@ export default class projectsJsonData {
     this.m_projectJsonData = JSON.parse(jsonData.toString());
   }
 
-  isValidInput(input: string, isHostParam: boolean) {
-    if (isHostParam) {
-      for (const key in this.m_projectJsonData.hostTypes) {
-        if (_.toLower(input) == key) {
-          return true;
-        }
+  isValidProjectType(input: string) {
+    for (const key in this.m_projectJsonData.projectTypes) {
+      if (_.toLower(input) == key) {
+        return true;
       }
-      return false;
     }
-    else {
-      for (const key in this.m_projectJsonData.projectTypes) {
-        if (_.toLower(input) == key) {
-          return true;
-        }
+    return false;
+  }
+
+  isValidHost(input: string) {
+    for (const key in this.m_projectJsonData.hostTypes) {
+      if (_.toLower(input) == key) {
+        return true;
       }
-      return false;
     }
+    return false;
+  }
+
+  isValidManifestType(input: string) {
+    for (const key in this.m_projectJsonData.manifestTypes) {
+      if (_.toLower(input) == key) {
+        return true;
+      }
+    }
+    return false;
   }
 
   getProjectDisplayName(projectType: string) {
@@ -49,8 +57,17 @@ export default class projectsJsonData {
     return this.m_projectJsonData.projectTypes[_.toLower(projectType)].templates.javascript != undefined && this.m_projectJsonData.projectTypes[_.toLower(projectType)].templates.typescript != undefined;
   }
 
-  getManifestPath(projectType: string): string | undefined {
-    return this.m_projectJsonData.projectTypes[projectType].manifestPath;
+  // getManifestPath(projectType: string): string | undefined {
+  //   return this.m_projectJsonData.projectTypes[projectType].manifestPath;
+  // }
+  getManifestOptions(projectType: string): string[] {
+    let manifestOptions: string[] = [];
+    for (const key in this.m_projectJsonData.projectTypes) {
+      if (key === projectType) {
+        manifestOptions = this.m_projectJsonData.projectTypes[key].supportedManifestTypes;
+      }
+    }
+    return manifestOptions;
   }
 
   getHostTemplateNames(projectType: string) {
@@ -85,6 +102,10 @@ export default class projectsJsonData {
       }
     }
     return undefined;
+  }
+
+  getManifestDisplayName(hostKey: string) {
+    return this.m_projectJsonData.manifestTypes[hostKey]?.displayname;
   }
 
   getProjectTemplateRepository(projectTypeKey: string, scriptType: string) {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -6,9 +6,7 @@ import * as _ from 'lodash';
 import * as chalk from 'chalk';
 import * as childProcess from "child_process";
 import * as defaults from "./defaults";
-import * as path from "path";
 import { helperMethods } from './helpers/helperMethods';
-import { OfficeAddinManifest } from 'office-addin-manifest';
 import projectsJsonData from './config/projectsJsonData';
 import { promisify } from "util";
 import * as usageData from "office-addin-usage-data";
@@ -59,6 +57,7 @@ module.exports = class extends yo {
     this.argument('projectType', { type: String, required: false });
     this.argument('name', { type: String, required: false });
     this.argument('host', { type: String, required: false });
+    this.argument('manifestType', { type: String, required: false });
 
     this.option('skip-install', {
       type: Boolean,
@@ -108,6 +107,7 @@ module.exports = class extends yo {
     }
     const message = `Welcome to the ${chalk.bold.green('Office Add-in')} generator, by ${chalk.bold.green('@OfficeDev')}! Let\'s create a project together!`;
     this.log(yosay(message));
+    jsonData = new projectsJsonData(this.templatePath());
   }
 
   /* Prompt user for project options */
@@ -133,7 +133,6 @@ module.exports = class extends yo {
         usageDataOptions.usageDataLevel = usageData.readUsageDataLevel(usageDataOptions.groupName);
       }
 
-      jsonData = new projectsJsonData(this.templatePath());
       let isManifestProject = false;
       let isExcelFunctionsProject = false;
 
@@ -152,7 +151,7 @@ module.exports = class extends yo {
           type: 'list',
           default: 'React',
           choices: jsonData.getProjectTemplateNames().map(template => ({ name: jsonData.getProjectDisplayName(template), value: template })),
-          when: this.options.projectType == null || !jsonData.isValidInput(this.options.projectType, false /* isHostParam */)
+          when: this.options.projectType == null || !jsonData.isValidProjectType(this.options.projectType)
         }
       ];
       const answerForProjectType = await this.prompt(askForProjectType);
@@ -205,14 +204,15 @@ module.exports = class extends yo {
       /* askForHost will be triggered if no project name was specified via the command line Host argument, and the Host argument
        * input was in fact valid, and the project type is not Excel-Functions */
       const startForHost = (new Date()).getTime();
+      const supportedHosts = jsonData.getHostTemplateNames(projectType);
       const askForHost = [{
         name: 'host',
         message: 'Which Office client application would you like to support?',
         type: 'list',
-        default: jsonData.getHostTemplateNames(projectType)[0],
-        choices: jsonData.getHostTemplateNames(projectType).map(host => ({ name: host, value: host })),
-        when: (this.options.host == null || this.options.host != null && !jsonData.isValidInput(this.options.host, true /* isHostParam */))
-          && jsonData.getHostTemplateNames(projectType).length > 1
+        default: supportedHosts[0],
+        choices: supportedHosts.map(host => ({ name: host, value: host })),
+        when: (this.options.host == null || this.options.host != null && !jsonData.isValidHost(this.options.host))
+          && supportedHosts.length > 1
       }];
       const answerForHost = await this.prompt(askForHost);
       const endForHost = (new Date()).getTime();
@@ -220,13 +220,32 @@ module.exports = class extends yo {
 
       usageDataObject = new usageData.OfficeAddinUsageData(usageDataOptions);
 
+      /* aksForManifestType will be triggered if no type was specified via the command line manifestType argument */
+      const startForManifestType = (new Date()).getTime();
+      const manifestOptions = jsonData.getManifestOptions(projectType);
+      const askForManifestType = [{
+        name: 'manifestType',
+        message: 'Which manifest type would you like to use?',
+        type: 'list',
+        default: manifestOptions[0],
+        choices: manifestOptions.map(manifestType => ({ name: jsonData.getManifestDisplayName(manifestType), value: manifestType })),
+        when: (this.options.manifestType == null || this.options.manifestType != null && !jsonData.isValidManifestType(this.options.manifestType))
+          && jsonData.getHostTemplateNames(projectType).length > 1
+      }];
+      const answerForManifestType = await this.prompt(askForManifestType);
+      const endForManifestType = (new Date()).getTime();
+      const durationForManifestType = (endForManifestType - startForManifestType) / 1000;
+
+      usageDataObject = new usageData.OfficeAddinUsageData(usageDataOptions);
+
       /* Configure project properties based on user input or answers to prompts */
-      this._configureProject(answerForProjectType, answerForScriptType, answerForHost, answerForName, isManifestProject, isExcelFunctionsProject);
+      this._configureProject(answerForProjectType, answerForManifestType, answerForScriptType, answerForHost, answerForName, isManifestProject, isExcelFunctionsProject);
       const projectInfo = {
         Host: [this.project.host, durationForHost],
         ScriptType: [this.project.scriptType],
         IsManifestOnly: [this.project.isManifestOnly.toString()],
         ProjectType: [this.project.projectType, durationForProjectType],
+        ManifestType: [this.project.manifestType, durationForManifestType],
         isForTesting: [usageDataOptions.isForTesting]
       };
       // Send usage data for project created
@@ -275,7 +294,7 @@ module.exports = class extends yo {
     }
   }
 
-  _configureProject(answerForProjectType, answerForScriptType, answerForHost, answerForName, isManifestProject, isExcelFunctionsProject): void {
+  _configureProject(answerForProjectType, answerForManifestType, answerForScriptType, answerForHost, answerForName, isManifestProject, isExcelFunctionsProject): void {
     try {
       const projType = _.toLower(this.options.projectType) || _.toLower(answerForProjectType.projectType)
 
@@ -286,6 +305,11 @@ module.exports = class extends yo {
           : this.options.host
           ? this.options.host
           : jsonData?.getHostTemplateNames(projType)[0],
+        manifestType: answerForManifestType.manifestType
+          ? answerForManifestType.manifestType
+          : this.options.manifestType
+          ? this.options.manifestType
+          : jsonData?.getManifestOptions(projType)[0],
         name: this.options.name || answerForName.name,
         projectType: projType,
         scriptType: answerForScriptType.scriptType
@@ -329,7 +353,6 @@ module.exports = class extends yo {
   async _copyProjectFiles(): Promise<void> {
     return new Promise(async (resolve, reject) => {
       try {
-        const jsonData = new projectsJsonData(this.templatePath());
         const projectRepoBranchInfo = jsonData.getProjectRepoAndBranch(this.project.projectType, language, this.options.prerelease);
 
         this._projectCreationMessage();
@@ -339,11 +362,8 @@ module.exports = class extends yo {
           await helperMethods.downloadProjectTemplateZipFile(this.destinationPath(), projectRepoBranchInfo.repo, projectRepoBranchInfo.branch);
 
           // Call 'convert-to-single-host' npm script in generated project, passing in host parameter
-          const cmdLine = `npm run convert-to-single-host --if-present -- ${_.toLower(this.project.hostInternalName)}`;
+          const cmdLine = `npm run convert-to-single-host --if-present -- ${_.toLower(this.project.hostInternalName)} ${this.project.manifestType} ${this.project.name}`;
           await childProcessExec(cmdLine);
-
-          // modify manifest guid and DisplayName
-          await OfficeAddinManifest.modifyManifestFile(`${path.join(this.destinationPath(), jsonData.getManifestPath(this.project.projectType))}`, 'random', `${this.project.name}`);
         }
         else {
           // Manifest-only project
@@ -412,7 +432,9 @@ module.exports = class extends yo {
     }
     else {
       this.log('\n----------------------------------------------------------------------------------\n');
-      this.log(`      Creating ${chalk.bold.green(this.project.projectDisplayName)} add-in for ${chalk.bold.magenta(_.capitalize(this.project.host))} using ${chalk.bold.yellow(this.project.scriptType)} and ${chalk.bold.green(_.capitalize(this.project.projectType))} at ${chalk.bold.magenta(this.destinationRoot())}\n`);
+      this.log(`      Creating ${chalk.bold.green(this.project.projectDisplayName)} add-in for ${chalk.bold.magenta(_.capitalize(this.project.host))}`);
+      this.log(`      using ${chalk.bold.yellow(this.project.scriptType)} and ${chalk.bold.magenta(jsonData.getProjectDisplayName(this.project.projectType))} and ${chalk.bold.yellow(jsonData.getManifestDisplayName(this.project.manifestType))}`);
+      this.log(`      at ${chalk.bold.magenta(this.destinationRoot())}\n`);
       this.log('----------------------------------------------------------------------------------');
     }
   }
@@ -421,20 +443,23 @@ module.exports = class extends yo {
     this.log(`\nYo Office ${chalk.bgGreen('Arguments')} and ${chalk.bgMagenta('Options.')}\n`);
     this.log(`NOTE: ${chalk.bgGreen('Arguments')} must be specified in the order below, and ${chalk.bgMagenta('Options')} must follow ${chalk.bgGreen('Arguments')}.\n`);
     this.log(`  ${chalk.bgGreen('projectType')}:Specifies the type of project to create. Valid project types include:`);
-    this.log(`    ${chalk.yellow('excel-functions-shared:')} Creates an Office add-in for Excel custom functions using a Shared Runtime.`);
-    this.log(`    ${chalk.yellow('excel-functions:')} Creates an Office add-in for Excel custom functions using a JavaScript-only Runtime.`);
-    this.log(`    ${chalk.yellow('jquery:')} Creates an Office add-in using Jquery framework.`);
-    this.log(`    ${chalk.yellow('manifest:')} Creates an only the manifest file for an Office add-in.`);
-    this.log(`    ${chalk.yellow('react:')} Creates an Office add-in using React framework.\n`);
-    this.log(`    ${chalk.yellow('unified-manifest:')} Creates Outlook Add-in with a unified Microsoft 365 manifest (preview).\n`);
+    this.log(`    ${chalk.yellow('taskpane:')} Creates an 'Office Add-in Task Pane project' project.`);
+    this.log(`    ${chalk.yellow('react:')} Creates an 'Office add-in using React framework' project.`);
+    this.log(`    ${chalk.yellow('excel-functions-shared:')} Creates an 'Office add-in for Excel custom functions using a Shared Runtime' project.`);
+    this.log(`    ${chalk.yellow('excel-functions:')} Creates an 'Office add-in for Excel custom functions using a JavaScript-only Runtime' project.`);
+    this.log(`    ${chalk.yellow('single-sign-on:')} Creates an 'Office Add-in Task Pane project supporting single sign-on' project.`);
+    this.log(`    ${chalk.yellow('manifest:')} Creates an only the manifest file for an Office add-in project.\n`);
     this.log(`  ${chalk.bgGreen('name')}:Specifies the name for the project that will be created.\n`);
-    this.log(`  ${chalk.bgGreen('host')}:Specifies the host app in the add-in manifest.`);
-    this.log(`    ${chalk.yellow('excel:')}  Creates an Office add-in for Excel. Valid hosts include:`);
+    this.log(`  ${chalk.bgGreen('host')}:Specifies the host app in the add-in manifest. Valid hosts include:`);
+    this.log(`    ${chalk.yellow('excel:')}  Creates an Office add-in for Excel.`);
     this.log(`    ${chalk.yellow('onenote:')} Creates an Office add-in for OneNote.`);
     this.log(`    ${chalk.yellow('outlook:')} Creates an Office add-in for Outlook.`);
     this.log(`    ${chalk.yellow('powerpoint:')} Creates an Office add-in for PowerPoint.`);
     this.log(`    ${chalk.yellow('project:')} Creates an Office add-in for Project.`);
     this.log(`    ${chalk.yellow('word:')} Creates an Office add-in for Word.\n`);
+    this.log(`  ${chalk.bgGreen('manifestType')}:Specifies the manifest type to use for the add-in. Valid types include:`);
+    this.log(`    ${chalk.yellow('xml:')}  Creates a XML manifest`);
+    this.log(`    ${chalk.yellow('json:')} Creates a Unified manifest for Microsoft 365.\n`);
     this.log(`  ${chalk.bgMagenta('--output')}:Specifies the location in the file system where the project will be created.`);
     this.log(`    ${chalk.yellow('If the option is not specified, the project will be created in the current folder')}\n`);
     this.log(`  ${chalk.bgMagenta('--js')}:Specifies that the project will use JavaScript instead of TypeScript.`);

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -10,7 +10,8 @@ import * as path from 'path';
 import { promisify } from "util";
 
 const hosts = ["excel", "onenote", "outlook", "powerpoint", "project", "word"];
-const manifestFile = "manifest.xml";
+const manifestXmlFile = "manifest.xml";
+const manifestJsonFile = "manifest.json";
 const packageJsonFile = "package.json";
 const readFileAsync = promisify(fs.readFile);
 const unexpectedManifestFiles = [
@@ -24,11 +25,11 @@ const unexpectedManifestFiles = [
 
 // Test to verify converting a project to a single host
 // for Office-Addin-Taskpane Typescript project using Excel host
-describe('Office-Add-Taskpane-Ts projects', () => {
+describe('Office-Addin-Taskpane-Ts projects', () => {
     const testProjectName = "TaskpaneProject"
     const expectedFiles = [
         packageJsonFile,
-        manifestFile,
+        manifestXmlFile,
         'src/taskpane/taskpane.ts',
     ]
     const unexpectedFiles = [
@@ -43,10 +44,11 @@ describe('Office-Add-Taskpane-Ts projects', () => {
         projectType: "taskpane",
         scriptType: "TypeScript",
         name: testProjectName,
-        host: hosts[0]
+        host: hosts[0],
+        manifestType: "xml"
     };
 
-    describe('Office-Add-Taskpane project', () => {
+    describe('Create project', () => {
         before((done) => {
             helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
         });
@@ -59,7 +61,7 @@ describe('Office-Add-Taskpane-Ts projects', () => {
         });
     });
 
-    describe('Package.json is updated appropriately', () => {
+    describe('Check Package.json', () => {
         it('Package.json is updated properly', async () => {
             const data: string = await readFileAsync(packageJsonFile, 'utf8');
             const content = JSON.parse(data);
@@ -76,21 +78,22 @@ describe('Office-Add-Taskpane-Ts projects', () => {
         });
     });
 
-    describe('Manifest.xml is updated appropriately', () => {
+    describe('Check Manifest.xml', () => {
         it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
             assert.equal(manifestInfo.hosts, "Workbook");
-            assert.equal(manifestInfo.displayName, testProjectName);
+            assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
         });
     });
 });
 
-// for Office-Addin-Taskpane Typescript project using Excel host
-describe('Office-Add-Taskpane-Ts prerelease projects', () => {
+// Test to verify converting a project to a single host
+// for Office-Addin-Taskpane Typescript project using Excel host and prerelease flag
+describe('Office-Addin-Taskpane-Ts prerelease projects', () => {
     const testProjectName = "TaskpaneProject"
     const expectedFiles = [
         packageJsonFile,
-        manifestFile,
+        manifestXmlFile,
         'src/taskpane/taskpane.ts',
     ]
     const unexpectedFiles = [
@@ -105,10 +108,11 @@ describe('Office-Add-Taskpane-Ts prerelease projects', () => {
         projectType: "taskpane",
         scriptType: "TypeScript",
         name: testProjectName,
-        host: hosts[0]
+        host: hosts[0],
+        manifestType: "xml"
     };
 
-     describe('Office-Add-Taskpane prerelease project', () => {
+    describe('Create prerelease project', () => {
         before((done) => {
             helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
         });
@@ -121,7 +125,7 @@ describe('Office-Add-Taskpane-Ts prerelease projects', () => {
         });
     });
 
-    describe('Package.json is updated appropriately', () => {
+    describe('Check Package.json ', () => {
         it('Package.json is updated properly', async () => {
             const data: string = await readFileAsync(packageJsonFile, 'utf8');
             const content = JSON.parse(data);
@@ -138,21 +142,85 @@ describe('Office-Add-Taskpane-Ts prerelease projects', () => {
         });
     });
 
-    describe('Manifest.xml is updated appropriately', () => {
+    describe('Check Manifest.xml', () => {
         it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
             assert.equal(manifestInfo.hosts, "Workbook");
-            assert.equal(manifestInfo.displayName, testProjectName);
+            assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+        });
+    });
+});
+
+// Test to verify converting a project to a single host
+// for Office-Addin-Taskpane Typescript project using Outlook host and a json manifest
+describe('Office-Addin-Taskpane-Ts json projects', () => {
+    const testProjectName = "TaskpaneProject"
+    const expectedFiles = [
+        packageJsonFile,
+        manifestJsonFile,
+        'src/taskpane/taskpane.ts',
+    ]
+    const unexpectedFiles = [
+        'src/taskpane/excel.ts',
+        'src/taskpane/onenote.ts',
+        'src/taskpane/outlook.ts',
+        'src/taskpane/powerpoint.ts',
+        'src/taskpane/project.ts',
+        'src/taskpane/word.ts'
+    ]
+    const answers = {
+        projectType: "taskpane",
+        scriptType: "TypeScript",
+        name: testProjectName,
+        host: hosts[2],
+        manifestType: "json"
+    };
+
+    describe('Create json project', () => {
+        before((done) => {
+            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
+        });
+
+        it('creates expected files', (done) => {
+            assert.file(expectedFiles);
+            assert.noFile(unexpectedFiles);
+            assert.noFile(unexpectedManifestFiles);
+            done();
+        });
+    });
+
+    describe('Check Package.json ', () => {
+        it('Package.json is updated properly', async () => {
+            const data: string = await readFileAsync(packageJsonFile, 'utf8');
+            const content = JSON.parse(data);
+            assert.equal(content.config["app_to_debug"], hosts[2]);
+
+            // Verify host-specific sideload and unload sripts have been removed
+            let unexexpectedScriptsFound = false;
+            Object.keys(content.scripts).forEach(function (key) {
+                if (key.includes("sideload:") || key.includes("unload:")) {
+                    unexexpectedScriptsFound = true;
+                }
+            });
+            assert.equal(unexexpectedScriptsFound, false);
+        });
+    });
+
+    describe('Check Manifest.json', () => {
+        it('Manifest.json is updated appropriately', async () => {
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestJsonFile);
+            assert.equal(manifestInfo.hosts, "mail");
+            assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
         });
     });
 });
 
 // Test to verify converting a project to a single host
 // for React Typescript project using PowerPoint host
-describe('Office-Add-Taskpane-React-Ts project', () => {
+describe('Office-Addin-Taskpane-React-Ts project', () => {
     const expectedFiles = [
         packageJsonFile,
-        manifestFile,
+        manifestXmlFile,
         'src/taskpane/components/App.tsx', ,
     ]
     const unexpectedFiles = [
@@ -167,10 +235,11 @@ describe('Office-Add-Taskpane-React-Ts project', () => {
         projectType: "react",
         scriptType: "TypeScript",
         name: "ReactProject",
-        host: hosts[3]
+        host: hosts[3],
+        manifestType: "xml"
     };
 
-    describe('Office-Add-Taskpane project', () => {
+    describe('Create project', () => {
         before((done) => {
             helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
         });
@@ -183,7 +252,7 @@ describe('Office-Add-Taskpane-React-Ts project', () => {
         });
     });
 
-    describe('Package.json is updated appropriately', () => {
+    describe('Check Package.json', () => {
         it('Package.json is updated properly', async () => {
             const data: string = await readFileAsync(packageJsonFile, 'utf8');
             const content = JSON.parse(data);
@@ -200,101 +269,175 @@ describe('Office-Add-Taskpane-React-Ts project', () => {
         });
     });
 
-    describe('Manifest.xml is updated appropriately', () => {
+    describe('Check Manifest.xml', () => {
         it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestFile);
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
             assert.equal(manifestInfo.hosts, "Presentation");
         });
     });
 });
 
-// // Test to verify converting a project to a single host
-// // for SSO Typescript project using Excel host
-// describe('Office-Add-Taskpane-SSO-TS project', () => {
-//     const expectedFiles = [
-//         packageJsonFile,
-//         manifestFile,
-//         '.ENV',
-//         'src/taskpane/taskpane.ts',
-//         'src/taskpane/taskpane.html',
-//         'src/taskpane/taskpane.css',
-//         'src/helpers/fallbackauthdialog.html',
-//         'src/helpers/fallbackauthdialog.ts',
-//         'src/helpers/fallbackauthhelper.ts',
-//         'src/helpers/ssoauthhelper.ts'
+// Test to verify converting a project to a single host using the cli
+// for Office-Addin-Taskpane Typescript project using Excel host
+describe('Office-Addin-Taskpane-Ts projects via cli', () => {
+    const testProjectName = "TaskpaneProject"
+    const expectedFiles = [
+        packageJsonFile,
+        manifestXmlFile,
+        'src/taskpane/taskpane.ts',
+    ]
+    const unexpectedFiles = [
+        'src/taskpane/excel.ts',
+        'src/taskpane/onenote.ts',
+        'src/taskpane/outlook.ts',
+        'src/taskpane/powerpoint.ts',
+        'src/taskpane/project.ts',
+        'src/taskpane/word.ts'
+    ]
+    const options = {
+        projectType: "taskpane",
+        name: testProjectName,
+        host: hosts[0],
+        manifestType: "xml",
+        ts: true,
+        test: true
+    };
+    const answers = {};
 
-//     ]
-//     const unexpectedFiles = [
-//         'src/taskpane/excel.ts',
-//         'src/taskpane/word.ts',
-//         'src/taskpane/powerpoint.ts',
-//         'manifest.excel.xml',
-//         'manifest.word.xml',
-//         'manifest.powerpoint.xml'
-//     ]
-//     const answers = {
-//         projectType: "single-sign-on",
-//         scriptType: "TypeScript",
-//         name: "SSOTypeScriptProject",
-//         host: hosts[0]
-//     };
+    describe('Create project', () => {
+        before((done) => {
+            helpers.run(path.join(__dirname, '../app')).withOptions(options).withPrompts(answers).on('end', done);
+        });
 
-//     describe('Office-Add-Taskpane-SSO-TS project', () => {
-//         before((done) => {
-//             helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-//         });
+        it('creates expected files', (done) => {
+            assert.file(expectedFiles);
+            assert.noFile(unexpectedFiles);
+            assert.noFile(unexpectedManifestFiles);
+            done();
+        });
+    });
 
-//         it('creates expected files', (done) => {
-//             assert.file(expectedFiles);
-//             assert.noFile(unexpectedFiles);
-//             assert.noFile(unexpectedManifestFiles);
-//             done();
-//         });
-//     });
-// });
+    describe('Check Package.json', () => {
+        it('Package.json is updated properly', async () => {
+            const data: string = await readFileAsync(packageJsonFile, 'utf8');
+            const content = JSON.parse(data);
+            assert.equal(content.config["app_to_debug"], hosts[0]);
 
-// // Test to verify converting a project to a single host
-// // for SSO JavaScript project using PowerPoint host
-// describe('Office-Add-Taskpane-SSO-JS project', () => {
-//     const expectedFiles = [
-//         packageJsonFile,
-//         manifestFile,
-//         '.ENV',
-//         'src/taskpane/taskpane.js',
-//         'src/taskpane/taskpane.html',
-//         'src/taskpane/taskpane.css',
-//         'src/helpers/documenthelper.js',
-//         'src/helpers/fallbackauthdialog.html',
-//         'src/helpers/fallbackauthdialog.js',
-//         'src/helpers/fallbackauthhelper.js',
-//         'src/helpers/ssoauthhelper.js'
+            // Verify host-specific sideload and unload sripts have been removed
+            let unexexpectedScriptsFound = false;
+            Object.keys(content.scripts).forEach(function (key) {
+                if (key.includes("sideload:") || key.includes("unload:")) {
+                    unexexpectedScriptsFound = true;
+                }
+            });
+            assert.equal(unexexpectedScriptsFound, false);
+        });
+    });
 
-//     ]
-//     const unexpectedFiles = [
-//         'src/taskpane/excel.js',
-//         'src/taskpane/word.js',
-//         'src/taskpane/powerpoint.js',
-//         'manifest.excel.xml',
-//         'manifest.word.xml',
-//         'manifest.powerpoint.xml'
-//     ]
-//     const answers = {
-//         projectType: "single-sign-on",
-//         scriptType: "JavaScript",
-//         name: "SSOJavaScriptProject",
-//         host: hosts[3]
-//     };
+    describe('Check Manifest.xml', () => {
+        it('Manifest.xml is updated appropriately', async () => {
+            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+            assert.equal(manifestInfo.hosts, "Workbook");
+            assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+        });
+    });
+});
 
-//     describe('Office-Add-Taskpane-SSO-JS project', () => {
-//         before((done) => {
-//             helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-//         });
+// Test to verify converting a project to a single host
+// for SSO Typescript project using Excel host
+describe('Office-Addin-Taskpane-SSO-TS project', () => {
+    const expectedFiles = [
+        packageJsonFile,
+        manifestXmlFile,
+        '.ENV',
+        'src/taskpane/taskpane.ts',
+        'src/taskpane/taskpane.html',
+        'src/taskpane/taskpane.css',
+        'src/helpers/fallbackauthdialog.html',
+        'src/helpers/fallbackauthdialog.ts',
+        'src/helpers/message-helper.ts',
+        'src/helpers/middle-tier-calls.ts',
+        'src/helpers/sso-helper.ts',
+        'src/middle-tier/app.ts',
+        'src/middle-tier/msgraph-helper.ts',
+        'src/middle-tier/ssoauth-helper.ts'
+    ]
+    const unexpectedFiles = [
+        'src/taskpane/excel.ts',
+        'src/taskpane/word.ts',
+        'src/taskpane/powerpoint.ts',
+        'manifest.excel.xml',
+        'manifest.word.xml',
+        'manifest.powerpoint.xml'
+    ]
+    const answers = {
+        projectType: "single-sign-on",
+        scriptType: "TypeScript",
+        name: "SSOTypeScriptProject",
+        host: hosts[0],
+        manifestType: "xml"
+    };
 
-//         it('creates expected files', (done) => {
-//             assert.file(expectedFiles);
-//             assert.noFile(unexpectedFiles);
-//             assert.noFile(unexpectedManifestFiles);
-//             done();
-//         });
-//     });
-// });
+    describe('Office-Addin-Taskpane-SSO-TS project', () => {
+        before((done) => {
+            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+        });
+
+        it('creates expected files', (done) => {
+            assert.file(expectedFiles);
+            assert.noFile(unexpectedFiles);
+            assert.noFile(unexpectedManifestFiles);
+            done();
+        });
+    });
+});
+
+// Test to verify converting a project to a single host
+// for SSO JavaScript project using PowerPoint host
+describe('Office-Addin-Taskpane-SSO-JS project', () => {
+    const expectedFiles = [
+        packageJsonFile,
+        manifestXmlFile,
+        '.ENV',
+        'src/taskpane/taskpane.js',
+        'src/taskpane/taskpane.html',
+        'src/taskpane/taskpane.css',
+        'src/helpers/documenthelper.js',
+        'src/helpers/fallbackauthdialog.html',
+        'src/helpers/fallbackauthdialog.js',
+        'src/helpers/message-helper.js',
+        'src/helpers/middle-tier-calls.js',
+        'src/helpers/sso-helper.js',
+        'src/middle-tier/app.js',
+        'src/middle-tier/msgraph-helper.js',
+        'src/middle-tier/ssoauth-helper.js'
+    ]
+    const unexpectedFiles = [
+        'src/taskpane/excel.js',
+        'src/taskpane/word.js',
+        'src/taskpane/powerpoint.js',
+        'manifest.excel.xml',
+        'manifest.word.xml',
+        'manifest.powerpoint.xml'
+    ]
+    const answers = {
+        projectType: "single-sign-on",
+        scriptType: "JavaScript",
+        name: "SSOJavaScriptProject",
+        host: hosts[3],
+        manifestType: "xml"
+    };
+
+    describe('Office-Addin-Taskpane-SSO-JS project', () => {
+        before((done) => {
+            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+        });
+
+        it('creates expected files', (done) => {
+            assert.file(expectedFiles);
+            assert.noFile(unexpectedFiles);
+            assert.noFile(unexpectedManifestFiles);
+            done();
+        });
+    });
+});

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -48,42 +48,36 @@ describe('Office-Addin-Taskpane-Ts projects', () => {
         manifestType: "xml"
     };
 
-    describe('Create project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-        });
-
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
     });
 
-    describe('Check Package.json', () => {
-        it('Package.json is updated properly', async () => {
-            const data: string = await readFileAsync(packageJsonFile, 'utf8');
-            const content = JSON.parse(data);
-            assert.equal(content.config["app_to_debug"], hosts[0]);
-
-            // Verify host-specific sideload and unload sripts have been removed
-            let unexexpectedScriptsFound = false;
-            Object.keys(content.scripts).forEach(function (key) {
-                if (key.includes("sideload:") || key.includes("unload:")) {
-                    unexexpectedScriptsFound = true;
-                }
-            });
-            assert.equal(unexexpectedScriptsFound, false);
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 
-    describe('Check Manifest.xml', () => {
-        it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-            assert.equal(manifestInfo.hosts, "Workbook");
-            assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+    it('Package.json is updated properly', async () => {
+        const data: string = await readFileAsync(packageJsonFile, 'utf8');
+        const content = JSON.parse(data);
+        assert.equal(content.config["app_to_debug"], hosts[0]);
+
+        // Verify host-specific sideload and unload sripts have been removed
+        let unexexpectedScriptsFound = false;
+        Object.keys(content.scripts).forEach(function (key) {
+            if (key.includes("sideload:") || key.includes("unload:")) {
+                unexexpectedScriptsFound = true;
+            }
         });
+        assert.equal(unexexpectedScriptsFound, false);
+    });
+
+    it('Manifest.xml is updated appropriately', async () => {
+        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts, "Workbook");
+        assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
 
@@ -112,42 +106,35 @@ describe('Office-Addin-Taskpane-Ts prerelease projects', () => {
         manifestType: "xml"
     };
 
-    describe('Create prerelease project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
-        });
-
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
     });
 
-    describe('Check Package.json ', () => {
-        it('Package.json is updated properly', async () => {
-            const data: string = await readFileAsync(packageJsonFile, 'utf8');
-            const content = JSON.parse(data);
-            assert.equal(content.config["app_to_debug"], hosts[0]);
-
-            // Verify host-specific sideload and unload sripts have been removed
-            let unexexpectedScriptsFound = false;
-            Object.keys(content.scripts).forEach(function (key) {
-                if (key.includes("sideload:") || key.includes("unload:")) {
-                    unexexpectedScriptsFound = true;
-                }
-            });
-            assert.equal(unexexpectedScriptsFound, false);
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 
-    describe('Check Manifest.xml', () => {
-        it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-            assert.equal(manifestInfo.hosts, "Workbook");
-            assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+    it('Package.json is updated properly', async () => {
+        const data: string = await readFileAsync(packageJsonFile, 'utf8');
+        const content = JSON.parse(data);
+        assert.equal(content.config["app_to_debug"], hosts[0]);
+
+        // Verify host-specific sideload and unload sripts have been removed
+        let unexexpectedScriptsFound = false;
+        Object.keys(content.scripts).forEach(function (key) {
+            if (key.includes("sideload:") || key.includes("unload:")) {
+                unexexpectedScriptsFound = true;
+            }
         });
+        assert.equal(unexexpectedScriptsFound, false);
+    });
+    it('Manifest.xml is updated appropriately', async () => {
+        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts, "Workbook");
+        assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
 
@@ -176,42 +163,36 @@ describe('Office-Addin-Taskpane-Ts json projects', () => {
         manifestType: "json"
     };
 
-    describe('Create json project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
-        });
-
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
     });
 
-    describe('Check Package.json ', () => {
-        it('Package.json is updated properly', async () => {
-            const data: string = await readFileAsync(packageJsonFile, 'utf8');
-            const content = JSON.parse(data);
-            assert.equal(content.config["app_to_debug"], hosts[2]);
-
-            // Verify host-specific sideload and unload sripts have been removed
-            let unexexpectedScriptsFound = false;
-            Object.keys(content.scripts).forEach(function (key) {
-                if (key.includes("sideload:") || key.includes("unload:")) {
-                    unexexpectedScriptsFound = true;
-                }
-            });
-            assert.equal(unexexpectedScriptsFound, false);
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 
-    describe('Check Manifest.json', () => {
-        it('Manifest.json is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestJsonFile);
-            assert.equal(manifestInfo.hosts, "mail");
-            assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+    it('Package.json is updated properly', async () => {
+        const data: string = await readFileAsync(packageJsonFile, 'utf8');
+        const content = JSON.parse(data);
+        assert.equal(content.config["app_to_debug"], hosts[2]);
+
+        // Verify host-specific sideload and unload sripts have been removed
+        let unexexpectedScriptsFound = false;
+        Object.keys(content.scripts).forEach(function (key) {
+            if (key.includes("sideload:") || key.includes("unload:")) {
+                unexexpectedScriptsFound = true;
+            }
         });
+        assert.equal(unexexpectedScriptsFound, false);
+    });
+
+    it('Manifest.json is updated appropriately', async () => {
+        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestJsonFile);
+        assert.equal(manifestInfo.hosts, "mail");
+        assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
 
@@ -239,41 +220,35 @@ describe('Office-Addin-Taskpane-React-Ts project', () => {
         manifestType: "xml"
     };
 
-    describe('Create project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-        });
-
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
     });
 
-    describe('Check Package.json', () => {
-        it('Package.json is updated properly', async () => {
-            const data: string = await readFileAsync(packageJsonFile, 'utf8');
-            const content = JSON.parse(data);
-            assert.equal(content.config["app_to_debug"], hosts[3]);
-
-            // Verify host-specific sideload and unload sripts have been removed
-            let unexexpectedScriptsFound = false;
-            Object.keys(content.scripts).forEach(function (key) {
-                if (key.includes("sideload:") || key.includes("unload:")) {
-                    unexexpectedScriptsFound = true;
-                }
-            });
-            assert.equal(unexexpectedScriptsFound, false);
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 
-    describe('Check Manifest.xml', () => {
-        it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-            assert.equal(manifestInfo.hosts, "Presentation");
+    it('Package.json is updated properly', async () => {
+        const data: string = await readFileAsync(packageJsonFile, 'utf8');
+        const content = JSON.parse(data);
+        assert.equal(content.config["app_to_debug"], hosts[3]);
+
+        // Verify host-specific sideload and unload sripts have been removed
+        let unexexpectedScriptsFound = false;
+        Object.keys(content.scripts).forEach(function (key) {
+            if (key.includes("sideload:") || key.includes("unload:")) {
+                unexexpectedScriptsFound = true;
+            }
         });
+        assert.equal(unexexpectedScriptsFound, false);
+    });
+
+    it('Manifest.xml is updated appropriately', async () => {
+        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts, "Presentation");
     });
 });
 
@@ -304,42 +279,36 @@ describe('Office-Addin-Taskpane-Ts projects via cli', () => {
     };
     const answers = {};
 
-    describe('Create project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions(options).withPrompts(answers).on('end', done);
-        });
-
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions(options).withPrompts(answers).on('end', done);
     });
 
-    describe('Check Package.json', () => {
-        it('Package.json is updated properly', async () => {
-            const data: string = await readFileAsync(packageJsonFile, 'utf8');
-            const content = JSON.parse(data);
-            assert.equal(content.config["app_to_debug"], hosts[0]);
-
-            // Verify host-specific sideload and unload sripts have been removed
-            let unexexpectedScriptsFound = false;
-            Object.keys(content.scripts).forEach(function (key) {
-                if (key.includes("sideload:") || key.includes("unload:")) {
-                    unexexpectedScriptsFound = true;
-                }
-            });
-            assert.equal(unexexpectedScriptsFound, false);
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 
-    describe('Check Manifest.xml', () => {
-        it('Manifest.xml is updated appropriately', async () => {
-            const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-            assert.equal(manifestInfo.hosts, "Workbook");
-            assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+    it('Package.json is updated properly', async () => {
+        const data: string = await readFileAsync(packageJsonFile, 'utf8');
+        const content = JSON.parse(data);
+        assert.equal(content.config["app_to_debug"], hosts[0]);
+
+        // Verify host-specific sideload and unload sripts have been removed
+        let unexexpectedScriptsFound = false;
+        Object.keys(content.scripts).forEach(function (key) {
+            if (key.includes("sideload:") || key.includes("unload:")) {
+                unexexpectedScriptsFound = true;
+            }
         });
+        assert.equal(unexexpectedScriptsFound, false);
+    });
+
+    it('Manifest.xml is updated appropriately', async () => {
+        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts, "Workbook");
+        assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
 
@@ -378,17 +347,15 @@ describe('Office-Addin-Taskpane-SSO-TS project', () => {
         manifestType: "xml"
     };
 
-    describe('Office-Addin-Taskpane-SSO-TS project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+    });
 
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 });
 
@@ -428,16 +395,14 @@ describe('Office-Addin-Taskpane-SSO-JS project', () => {
         manifestType: "xml"
     };
 
-    describe('Office-Addin-Taskpane-SSO-JS project', () => {
-        before((done) => {
-            helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-        });
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+    });
 
-        it('creates expected files', (done) => {
-            assert.file(expectedFiles);
-            assert.noFile(unexpectedFiles);
-            assert.noFile(unexpectedManifestFiles);
-            done();
-        });
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
     });
 });

--- a/src/test/manifest-only-project.ts
+++ b/src/test/manifest-only-project.ts
@@ -41,16 +41,14 @@ describe('manifest project - answers', () => {
     host: 'Excel',
   };
 
-  describe('manifest', () => {
-    before((done) => {
-      helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-    });
+  before((done) => {
+    helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+  });
 
-    it('creates expected files', (done) => {
-      assert.file(expectedFiles);
-      assert.noFile(unexpectedFiles);
-      done();
-    });
+  it('creates expected files', (done) => {
+    assert.file(expectedFiles);
+    assert.noFile(unexpectedFiles);
+    done();
   });
 });
 
@@ -65,17 +63,15 @@ describe('manifest project - answers & args', () => {
   };
   const argument = [];
 
-  describe('argument: project', () => {
-    before((done) => {
-      argument[0] = manifestProject;
-      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-    });
+  before((done) => {
+    argument[0] = manifestProject;
+    helpers.run(path.join(__dirname, '../app')).withArguments(argument).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+  });
 
-    it('creates expected files', (done) => {
-      assert.file(expectedFiles);
-      assert.noFile(unexpectedFiles);
-      done();
-    });
+  it('creates expected files', (done) => {
+    assert.file(expectedFiles);
+    assert.noFile(unexpectedFiles);
+    done();
   });
 });
 
@@ -89,18 +85,16 @@ describe('manifest project - answers & args', () => {
   };
   const argument = [];
 
-  describe('argument: project', () => {
-    before((done) => {
-      argument[0] = manifestProject;
-      argument[1] = projectEscapedName;
-      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-    });
+  before((done) => {
+    argument[0] = manifestProject;
+    argument[1] = projectEscapedName;
+    helpers.run(path.join(__dirname, '../app')).withArguments(argument).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+  });
 
-    it('creates expected files', (done) => {
-      assert.file(expectedFiles);
-      assert.noFile(unexpectedFiles);
-      done();
-    });
+  it('creates expected files', (done) => {
+    assert.file(expectedFiles);
+    assert.noFile(unexpectedFiles);
+    done();
   });
 });
 
@@ -112,18 +106,16 @@ describe('manifest project - answers & args', () => {
   const answers = {};
   const argument = [];
 
-  describe('argument: project', () => {
-    before((done) => {
-      argument[0] = manifestProject;
-      argument[1] = projectEscapedName;
-      argument[2] = 'Excel';
-      helpers.run(path.join(__dirname, '../app')).withArguments(argument).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
-    });
+  before((done) => {
+    argument[0] = manifestProject;
+    argument[1] = projectEscapedName;
+    argument[2] = 'Excel';
+    helpers.run(path.join(__dirname, '../app')).withArguments(argument).withOptions({ 'test': true }).withPrompts(answers).on('end', done);
+  });
 
-    it('creates expected files', (done) => {
-      assert.file(expectedFiles);
-      assert.noFile(unexpectedFiles);
-      done();
-    });
+  it('creates expected files', (done) => {
+    assert.file(expectedFiles);
+    assert.noFile(unexpectedFiles);
+    done();
   });
 });


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

Point to the single template repo branch for both the xml manifest project and the json project.  Also stopped updating the manifest (GUID and title) here and left that for the template convert script.  Also fixed the security alert for ip *.


1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

There is now the possibility of getting json manifest project or xml manifest project based on the same template

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [x]  Yes
    > * [ ]  No

Documentation for creating json projects will need to be updated to the new set of questions.

3. **Validation/testing performed**:

    Ran automated tests.  Also generated projects for json and xml manually.  Ran one of those projects as well.

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
