### PR TITLE
Make manifest type support host specific and improve tests

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -12,18 +12,39 @@
                     "branch": "yo-office"
                 }
             },
-            "supportedManifestTypes": [
-                "xml",
-                "json"
-            ],
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Onenote": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Outlook": {
+                    "supportedManifestTypes": [
+                        "xml",
+                        "json"
+                    ]
+                },
+                "Powerpoint": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Project": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Word": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
         },
         "react": {
             "displayname": "Office Add-in Task Pane project using React framework",
@@ -37,17 +58,38 @@
                     "branch": "yo-office"
                 }
             },
-            "supportedManifestTypes": [
-                "xml"
-            ],
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Onenote": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Outlook": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Powerpoint": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Project": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Word": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
         },
         "excel-functions-shared": {
             "displayname": "Excel Custom Functions using a Shared Runtime",
@@ -63,12 +105,13 @@
                     "prerelease": "shared-runtime"
                 }
             },
-            "supportedManifestTypes": [
-                "xml"
-            ],
-            "supportedHosts": [
-                "Excel"
-            ]
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
         },
         "excel-functions": {
             "displayname": "Excel Custom Functions using a JavaScript-only Runtime",
@@ -82,12 +125,13 @@
                     "branch": "yo-office"
                 }
             },
-            "supportedManifestTypes": [
-                "xml"
-            ],
-            "supportedHosts": [
-                "Excel"
-            ]
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
         },
         "single-sign-on": {
             "displayname": "Office Add-in Task Pane project supporting single sign-on",
@@ -101,15 +145,28 @@
                     "branch": "yo-office"
                 }
             },
-            "supportedManifestTypes": [
-                "xml"
-            ],
-            "supportedHosts": [
-                "Excel",
-                "Outlook",
-                "Powerpoint",
-                "Word"
-            ]
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Outlook": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Powerpoint": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Word": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
         },
         "manifest": {
             "displayname": "Office Add-in project containing the manifest only",
@@ -118,17 +175,38 @@
                     "repository": ""
                 }
             },
-            "supportedManifestTypes": [
-                "xml"
-            ],
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Onenote": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Outlook": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Powerpoint": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Project": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Word": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
         }
     },
     "hostTypes": {

--- a/src/app/config/projectsJsonData.ts
+++ b/src/app/config/projectsJsonData.ts
@@ -10,7 +10,7 @@ export default class projectsJsonData {
     this.m_projectJsonData = JSON.parse(jsonData.toString());
   }
 
-  isValidProjectType(input: string) {
+  isValidProjectType(input: string): boolean {
     for (const key in this.m_projectJsonData.projectTypes) {
       if (_.toLower(input) == key) {
         return true;
@@ -19,7 +19,7 @@ export default class projectsJsonData {
     return false;
   }
 
-  isValidHost(input: string) {
+  isValidHost(input: string): boolean {
     for (const key in this.m_projectJsonData.hostTypes) {
       if (_.toLower(input) == key) {
         return true;
@@ -28,7 +28,7 @@ export default class projectsJsonData {
     return false;
   }
 
-  isValidManifestType(input: string) {
+  isValidManifestType(input: string): boolean {
     for (const key in this.m_projectJsonData.manifestTypes) {
       if (_.toLower(input) == key) {
         return true;
@@ -37,7 +37,7 @@ export default class projectsJsonData {
     return false;
   }
 
-  getProjectDisplayName(projectType: string) {
+  getProjectDisplayName(projectType: string): string {
     return this.m_projectJsonData.projectTypes[_.toLower(projectType)].displayname;
   }
 
@@ -45,7 +45,7 @@ export default class projectsJsonData {
     return this.m_projectJsonData;
   }
 
-  getProjectTemplateNames() {
+  getProjectTemplateNames(): string[] {
     const projectTemplates: string[] = [];
     for (const key in this.m_projectJsonData.projectTypes) {
       projectTemplates.push(key);
@@ -53,34 +53,21 @@ export default class projectsJsonData {
     return projectTemplates;
   }
 
-  projectBothScriptTypes(projectType: string) {
+  projectBothScriptTypes(projectType: string): boolean {
     return this.m_projectJsonData.projectTypes[_.toLower(projectType)].templates.javascript != undefined && this.m_projectJsonData.projectTypes[_.toLower(projectType)].templates.typescript != undefined;
   }
 
-  // getManifestPath(projectType: string): string | undefined {
-  //   return this.m_projectJsonData.projectTypes[projectType].manifestPath;
-  // }
-  getManifestOptions(projectType: string): string[] {
-    let manifestOptions: string[] = [];
-    for (const key in this.m_projectJsonData.projectTypes) {
-      if (key === projectType) {
-        manifestOptions = this.m_projectJsonData.projectTypes[key].supportedManifestTypes;
-      }
-    }
-    return manifestOptions;
+  getManifestOptions(projectType: string, host: string): string[] {
+    const selectedHost = this.m_projectJsonData.projectTypes[projectType]?.supportedHosts[host];
+    return selectedHost ? selectedHost.supportedManifestTypes : [];
   }
 
-  getHostTemplateNames(projectType: string) {
-    let hosts: string[] = [];
-    for (const key in this.m_projectJsonData.projectTypes) {
-      if (key === projectType) {
-        hosts = this.m_projectJsonData.projectTypes[key].supportedHosts;
-      }
-    }
-    return hosts;
+  getHostOptions(projectType: string): string[] {
+    const selectedProjectType = this.m_projectJsonData.projectTypes[projectType];
+    return selectedProjectType ? Object.keys(selectedProjectType.supportedHosts) : [];
   }
 
-  getSupportedScriptTypes(projectType: string) {
+  getScriptTypeOptions(projectType: string): string[] {
     const scriptTypes: string[] = [];
     for (const template in this.m_projectJsonData.projectTypes[projectType].templates) {
       let scriptType: string;
@@ -95,7 +82,7 @@ export default class projectsJsonData {
     return scriptTypes;
   }
 
-  getHostDisplayName(hostKey: string) {
+  getHostDisplayName(hostKey: string): string {
     for (const key in this.m_projectJsonData.hostTypes) {
       if (_.toLower(hostKey) == key) {
         return this.m_projectJsonData.hostTypes[key].displayname;
@@ -104,11 +91,11 @@ export default class projectsJsonData {
     return undefined;
   }
 
-  getManifestDisplayName(hostKey: string) {
+  getManifestDisplayName(hostKey: string): string {
     return this.m_projectJsonData.manifestTypes[hostKey]?.displayname;
   }
 
-  getProjectTemplateRepository(projectTypeKey: string, scriptType: string) {
+  getProjectTemplateRepository(projectTypeKey: string, scriptType: string): string | undefined {
     for (const key in this.m_projectJsonData.projectTypes) {
       if (_.toLower(projectTypeKey) == key) {
         if (projectTypeKey == 'manifest') {
@@ -122,7 +109,7 @@ export default class projectsJsonData {
     return undefined;
   }
 
-  getProjectTemplateBranchName(projectTypeKey: string, scriptType: string, prerelease: boolean) {
+  getProjectTemplateBranchName(projectTypeKey: string, scriptType: string, prerelease: boolean): string | undefined {
     for (const key in this.m_projectJsonData.projectTypes) {
       if (_.toLower(projectTypeKey) == key) {
         if (projectTypeKey == 'manifest') {

--- a/src/test/convert-to-single-host.ts
+++ b/src/test/convert-to-single-host.ts
@@ -5,11 +5,11 @@
 import * as assert from 'yeoman-assert';
 import * as fs from "fs";
 import * as helpers from 'yeoman-test';
-import { OfficeAddinManifest } from "office-addin-manifest";
+import { OfficeAddinManifest, ManifestInfo } from "office-addin-manifest";
 import * as path from 'path';
 import { promisify } from "util";
 
-const hosts = ["excel", "onenote", "outlook", "powerpoint", "project", "word"];
+const hosts = ["Excel", "Onenote", "Outlook", "Powerpoint", "Project", "Word"];
 const manifestXmlFile = "manifest.xml";
 const manifestJsonFile = "manifest.json";
 const packageJsonFile = "package.json";
@@ -44,8 +44,7 @@ describe('Office-Addin-Taskpane-Ts projects', () => {
         projectType: "taskpane",
         scriptType: "TypeScript",
         name: testProjectName,
-        host: hosts[0],
-        manifestType: "xml"
+        host: hosts[0]
     };
 
     before((done) => {
@@ -62,7 +61,7 @@ describe('Office-Addin-Taskpane-Ts projects', () => {
     it('Package.json is updated properly', async () => {
         const data: string = await readFileAsync(packageJsonFile, 'utf8');
         const content = JSON.parse(data);
-        assert.equal(content.config["app_to_debug"], hosts[0]);
+        assert.equal(content.config["app_to_debug"], hosts[0].toLowerCase());
 
         // Verify host-specific sideload and unload sripts have been removed
         let unexexpectedScriptsFound = false;
@@ -75,8 +74,8 @@ describe('Office-Addin-Taskpane-Ts projects', () => {
     });
 
     it('Manifest.xml is updated appropriately', async () => {
-        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-        assert.equal(manifestInfo.hosts, "Workbook");
+        const manifestInfo : ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts[0], "Workbook");
         assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
@@ -102,8 +101,7 @@ describe('Office-Addin-Taskpane-Ts prerelease projects', () => {
         projectType: "taskpane",
         scriptType: "TypeScript",
         name: testProjectName,
-        host: hosts[0],
-        manifestType: "xml"
+        host: hosts[0]
     };
 
     before((done) => {
@@ -120,7 +118,7 @@ describe('Office-Addin-Taskpane-Ts prerelease projects', () => {
     it('Package.json is updated properly', async () => {
         const data: string = await readFileAsync(packageJsonFile, 'utf8');
         const content = JSON.parse(data);
-        assert.equal(content.config["app_to_debug"], hosts[0]);
+        assert.equal(content.config["app_to_debug"], hosts[0].toLowerCase());
 
         // Verify host-specific sideload and unload sripts have been removed
         let unexexpectedScriptsFound = false;
@@ -132,15 +130,15 @@ describe('Office-Addin-Taskpane-Ts prerelease projects', () => {
         assert.equal(unexexpectedScriptsFound, false);
     });
     it('Manifest.xml is updated appropriately', async () => {
-        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-        assert.equal(manifestInfo.hosts, "Workbook");
+        const manifestInfo : ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts[0], "Workbook");
         assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
 
 // Test to verify converting a project to a single host
 // for Office-Addin-Taskpane Typescript project using Outlook host and a json manifest
-describe('Office-Addin-Taskpane-Ts json projects', () => {
+describe('Office-Addin-Taskpane-Ts Outlook json project', () => {
     const testProjectName = "TaskpaneProject"
     const expectedFiles = [
         packageJsonFile,
@@ -177,7 +175,7 @@ describe('Office-Addin-Taskpane-Ts json projects', () => {
     it('Package.json is updated properly', async () => {
         const data: string = await readFileAsync(packageJsonFile, 'utf8');
         const content = JSON.parse(data);
-        assert.equal(content.config["app_to_debug"], hosts[2]);
+        assert.equal(content.config["app_to_debug"], hosts[2].toLowerCase());
 
         // Verify host-specific sideload and unload sripts have been removed
         let unexexpectedScriptsFound = false;
@@ -190,8 +188,66 @@ describe('Office-Addin-Taskpane-Ts json projects', () => {
     });
 
     it('Manifest.json is updated appropriately', async () => {
-        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestJsonFile);
-        assert.equal(manifestInfo.hosts, "mail");
+        const manifestInfo : ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestJsonFile);
+        assert.equal(manifestInfo.hosts[0], "mail");
+        assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
+    });
+});
+
+// Test to verify converting a project to a single host
+// for Office-Addin-Taskpane Typescript project using Outlook host and a xml manifest
+describe('Office-Addin-Taskpane-Ts Outlook xml project', () => {
+    const testProjectName = "TaskpaneProject"
+    const expectedFiles = [
+        packageJsonFile,
+        manifestXmlFile,
+        'src/taskpane/taskpane.ts',
+    ]
+    const unexpectedFiles = [
+        'src/taskpane/excel.ts',
+        'src/taskpane/onenote.ts',
+        'src/taskpane/outlook.ts',
+        'src/taskpane/powerpoint.ts',
+        'src/taskpane/project.ts',
+        'src/taskpane/word.ts'
+    ]
+    const answers = {
+        projectType: "taskpane",
+        scriptType: "TypeScript",
+        name: testProjectName,
+        host: hosts[2],
+        manifestType: "xml"
+    };
+
+    before((done) => {
+        helpers.run(path.join(__dirname, '../app')).withOptions({ 'test': true, 'prerelease': true }).withPrompts(answers).on('end', done);
+    });
+
+    it('creates expected files', (done) => {
+        assert.file(expectedFiles);
+        assert.noFile(unexpectedFiles);
+        assert.noFile(unexpectedManifestFiles);
+        done();
+    });
+
+    it('Package.json is updated properly', async () => {
+        const data: string = await readFileAsync(packageJsonFile, 'utf8');
+        const content = JSON.parse(data);
+        assert.equal(content.config["app_to_debug"], hosts[2].toLowerCase());
+
+        // Verify host-specific sideload and unload sripts have been removed
+        let unexexpectedScriptsFound = false;
+        Object.keys(content.scripts).forEach(function (key) {
+            if (key.includes("sideload:") || key.includes("unload:")) {
+                unexexpectedScriptsFound = true;
+            }
+        });
+        assert.equal(unexexpectedScriptsFound, false);
+    });
+
+    it('Manifest.xml is updated appropriately', async () => {
+        const manifestInfo : ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts[0], "Mailbox");
         assert.equal(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
@@ -216,8 +272,7 @@ describe('Office-Addin-Taskpane-React-Ts project', () => {
         projectType: "react",
         scriptType: "TypeScript",
         name: "ReactProject",
-        host: hosts[3],
-        manifestType: "xml"
+        host: hosts[3]
     };
 
     before((done) => {
@@ -234,7 +289,7 @@ describe('Office-Addin-Taskpane-React-Ts project', () => {
     it('Package.json is updated properly', async () => {
         const data: string = await readFileAsync(packageJsonFile, 'utf8');
         const content = JSON.parse(data);
-        assert.equal(content.config["app_to_debug"], hosts[3]);
+        assert.equal(content.config["app_to_debug"], hosts[3].toLowerCase());
 
         // Verify host-specific sideload and unload sripts have been removed
         let unexexpectedScriptsFound = false;
@@ -247,8 +302,8 @@ describe('Office-Addin-Taskpane-React-Ts project', () => {
     });
 
     it('Manifest.xml is updated appropriately', async () => {
-        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-        assert.equal(manifestInfo.hosts, "Presentation");
+        const manifestInfo : ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts[0], "Presentation");
     });
 });
 
@@ -273,7 +328,6 @@ describe('Office-Addin-Taskpane-Ts projects via cli', () => {
         projectType: "taskpane",
         name: testProjectName,
         host: hosts[0],
-        manifestType: "xml",
         ts: true,
         test: true
     };
@@ -293,7 +347,7 @@ describe('Office-Addin-Taskpane-Ts projects via cli', () => {
     it('Package.json is updated properly', async () => {
         const data: string = await readFileAsync(packageJsonFile, 'utf8');
         const content = JSON.parse(data);
-        assert.equal(content.config["app_to_debug"], hosts[0]);
+        assert.equal(content.config["app_to_debug"], hosts[0].toLowerCase());
 
         // Verify host-specific sideload and unload sripts have been removed
         let unexexpectedScriptsFound = false;
@@ -306,8 +360,8 @@ describe('Office-Addin-Taskpane-Ts projects via cli', () => {
     });
 
     it('Manifest.xml is updated appropriately', async () => {
-        const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
-        assert.equal(manifestInfo.hosts, "Workbook");
+        const manifestInfo : ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestXmlFile);
+        assert.equal(manifestInfo.hosts[0], "Workbook");
         assert.notEqual(manifestInfo.displayName, testProjectName); // TODO: update when new convert script is in yo-office template branches
     });
 });
@@ -343,8 +397,7 @@ describe('Office-Addin-Taskpane-SSO-TS project', () => {
         projectType: "single-sign-on",
         scriptType: "TypeScript",
         name: "SSOTypeScriptProject",
-        host: hosts[0],
-        manifestType: "xml"
+        host: hosts[0]
     };
 
     before((done) => {
@@ -391,8 +444,7 @@ describe('Office-Addin-Taskpane-SSO-JS project', () => {
         projectType: "single-sign-on",
         scriptType: "JavaScript",
         name: "SSOJavaScriptProject",
-        host: hosts[3],
-        manifestType: "xml"
+        host: hosts[3]
     };
 
     before((done) => {


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

Manifest type question is specific to host


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

Documentation not written yet, but this should be considered when it is.


3. **Validation/testing performed**:

    Manual project creation and automated tests

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
