### PR TITLE
Create a new option to initialize an NAA SSO (preview) project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ taskpane | Task Pane add-in using HTML
 react | Task Pane add-in using the React framework
 excel-functions | Task Pane add-in with Excel Custom Functions
 single-sign-on | Taskpane add-in supporting single-sign-on
+nested-app-auth | Taskpane add-in supporting Nested App Auth single sign-on (preview)
 manifest | Manifest and related files for an Office Add-in
 
 - Type: String

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -168,6 +168,32 @@
                 }
             }
         },
+        "nested-app-auth": {
+            "displayname": "Office Add-in Task Pane project supporting Nested App Auth single sign-on (preview)",
+            "templates": {
+                "typescript": {
+                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-SSO-NAA",
+                    "branch": "yo-office"
+                }
+            },
+            "supportedHosts": {
+                "Excel": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Powerpoint": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                },
+                "Word": {
+                    "supportedManifestTypes": [
+                        "xml"
+                    ]
+                }
+            }
+        },
         "manifest": {
             "displayname": "Office Add-in project containing the manifest only",
             "templates": {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -451,6 +451,7 @@ module.exports = class extends yo {
     this.log(`    ${chalk.yellow('excel-functions-shared:')} Creates an 'Office add-in for Excel custom functions using a Shared Runtime' project.`);
     this.log(`    ${chalk.yellow('excel-functions:')} Creates an 'Office add-in for Excel custom functions using a JavaScript-only Runtime' project.`);
     this.log(`    ${chalk.yellow('single-sign-on:')} Creates an 'Office Add-in Task Pane project supporting single sign-on' project.`);
+    this.log(`    ${chalk.yellow('nested-app-auth:')} Creates an 'Office Add-in Task Pane project supporting Nested App Auth single sign-on (preview)' project.`);
     this.log(`    ${chalk.yellow('manifest:')} Creates an only the manifest file for an Office add-in project.\n`);
     this.log(`  ${chalk.bgGreen('name')}:Specifies the name for the project that will be created.\n`);
     this.log(`  ${chalk.bgGreen('host')}:Specifies the host app in the add-in manifest. Valid hosts include:`);


### PR DESCRIPTION
Create a new option to initialize an NAA SSO (preview) project in generator-office. Only TypeScript is supported.

Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [X]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [X]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

The change is tested locally by replacing npm installation file with "yo office" command. The UI menu selector and command line are both tested.

Also test the sample project for Win32 and Office Online.

4. **Platforms tested**:

    > * [X ] Windows
    > * [ ] Mac
