### PR TITLE
Enable json manifests in more templates

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -71,7 +71,8 @@
                 },
                 "Outlook": {
                     "supportedManifestTypes": [
-                        "xml"
+                        "xml",
+                        "json"
                     ]
                 },
                 "Powerpoint": {
@@ -153,7 +154,8 @@
                 },
                 "Outlook": {
                     "supportedManifestTypes": [
-                        "xml"
+                        "xml",
+                        "json"
                     ]
                 },
                 "Powerpoint": {


### PR DESCRIPTION
Thank you for your pull request. Please provide the following information.

---

Adding the json manifest options for react and sso templates

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

They can generate a project with json manifests for sso and react

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [x]  Yes
    > * [ ]  No

Documentation should mention these options for these template types

3. **Validation/testing performed**:
Ran automation.  Also took a test package on another machine to see project generation.

4. **Platforms tested**:

    > * [X] Windows
    > * [ ] Mac
