### PR TITLE
XML manifest is being renamed to 'add-in only manifest'

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -259,10 +259,10 @@
     },
     "manifestTypes": {
         "xml": {
-            "displayname": "add-in only manifest"
+            "displayname": "Add-in only manifest"
         },
         "json": {
-            "displayname": "unified manifest for Microsoft 365"
+            "displayname": "Unified manifest for Microsoft 365"
         }
     }
 }

--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -259,7 +259,7 @@
     },
     "manifestTypes": {
         "xml": {
-            "displayname": "XML manifest"
+            "displayname": "add-in only manifest"
         },
         "json": {
             "displayname": "unified manifest for Microsoft 365"


### PR DESCRIPTION
This change is happening in the documentation, possibly within days, so we need the generator UI to match the new name. The point it to give the old manifest a name that contrasts with "unified manifest". Instead of one being named for its format and the other for its scope, they will now both be named for their scope. 

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ X]  Yes 
    > * [ ]  No

    If Yes, briefly describe what is impacted.

the XML manifest option is renamed

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [X ]  Yes
    > * [ ]  No

    If Yes, briefly describe what is impacted.

The Outlook quick start will need to match the new generator UI in text and screen shots.

3. **Validation/testing performed**:

    Describe manual testing done. 

4. **Platforms tested**:

    > * [ ] Windows
    > * [ ] Mac
