### PR TITLE
Fix typo in taskpane-preview project display name.

### DIFF
--- a/src/app/config/projectProperties.json
+++ b/src/app/config/projectProperties.json
@@ -47,7 +47,7 @@
             }
         },
         "taskpane-preview": {
-            "displayname": "Excel, PowerPoint, amd/or Word Task Pane with unified manifest for Microsoft 365 (preview)",
+            "displayname": "Excel, PowerPoint, and/or Word Task Pane with unified manifest for Microsoft 365 (preview)",
             "templates": {
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",


### PR DESCRIPTION
This pull request corrects a small typo from using the wording `amd/or` to `and/or` for the `taskpane-preview` project.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [x]  Yes
    > * [ ]  No

    When viewing project templates, the wording will be more correct.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No


3. **Validation/testing performed**:

  I built and ran the `yo office` command locally and confirmed the wording is correct.

![image](https://github.com/user-attachments/assets/dd6789d5-40c8-4c06-a65b-ef3d863a6d8b)

4. **Platforms tested**:

    > * [ ] Windows
    > * [x] Mac
