### PR TITLE
Fix console output for Project projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Claude Code files
+.claude/**
+CLAUDE.md
+
 # Ignore the following folders
 .vs
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -3246,6 +3246,31 @@
       "version": "8.0.0",
       "license": "MIT"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/env-cmd": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-11.0.0.tgz",

--- a/src/app/defaults.ts
+++ b/src/app/defaults.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 
 export const configurationErrorEventName = "configuration-error-generator-office";
 export const copyFilesErrorEventName = "copy-files-error-generator-office";
+export const generalSideloadingSteps = "https://learn.microsoft.com/office/dev/add-ins/testing/sideload-office-add-ins-for-testing";
 export const installDependenciesErrorEventName = "install-dependencies-error-generator-office";
 export const networkShareSideloadingSteps = "https://learn.microsoft.com/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins";
 export const outlookSideloadingSteps = "https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing";

--- a/src/app/defaults.ts
+++ b/src/app/defaults.ts
@@ -2,7 +2,6 @@ import chalk from "chalk";
 
 export const configurationErrorEventName = "configuration-error-generator-office";
 export const copyFilesErrorEventName = "copy-files-error-generator-office";
-export const generalSideloadingSteps = "https://learn.microsoft.com/office/dev/add-ins/testing/sideload-office-add-ins-for-testing";
 export const installDependenciesErrorEventName = "install-dependencies-error-generator-office";
 export const networkShareSideloadingSteps = "https://learn.microsoft.com/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins";
 export const outlookSideloadingSteps = "https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing";

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -433,9 +433,8 @@ export default class extends Generator {
       } else {
         await this.log(`      ${stepNumber++}. Start the local web server:\n`);
         await this.log(`         ${chalk.bold('npm run dev-server')}\n`);
-        await this.log(`      ${stepNumber++}. Sideload the the add-in:\n`);
-        await this.log(`         ${chalk.bold('Follow these instructions:')}`);
-        await this.log(`         ${defaults.networkShareSideloadingSteps}\n`);
+        await this.log(`      ${stepNumber++}. Sideload the add-in:\n`);
+        await this.log(`         Please visit ${defaults.generalSideloadingSteps} for sideloading instructions.\n`);
       }
     }
 
@@ -506,6 +505,9 @@ export default class extends Generator {
   }
 
   _exitProcess(): void {
-    process.exit();
+    // Ensure all output is flushed before exiting
+    process.stdout.write('', () => {
+      process.exit();
+    });
   }
 };

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -434,7 +434,7 @@ export default class extends Generator {
         await this.log(`      ${stepNumber++}. Start the local web server:\n`);
         await this.log(`         ${chalk.bold('npm run dev-server')}\n`);
         await this.log(`      ${stepNumber++}. Sideload the add-in:\n`);
-        await this.log(`         Please visit ${defaults.generalSideloadingSteps} for sideloading instructions.\n`);
+        await this.log(`         Please visit ${defaults.networkShareSideloadingSteps} for sideloading instructions.\n`);
       }
     }
 


### PR DESCRIPTION
Here is the current output when you make a take pane project for Project:

```
      Congratulations! Your add-in has been created! Your next steps:

      1. Go the directory where your project was created:

         cd C:\GitHub\HelloProjectOData

      2. Start the local web server:

         npm run dev-server

      3. Sideload the the add-in:

         Follow these instructions:
```

Note both the typo and the missing link. The issue is that the log buffer doesn't always get flushed. I also reframed the text to look more like the other host paths.


Thank you for your pull request. Please provide the following information.

---

1. **Do these changes impact *User Experience*?** (e.g., how the user interacts with Yo Office and/or the files and folders the user sees in the project that Yo Office creates)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    > 
    > * [ ]  Yes
    > * [x]  No

    If Yes, briefly describe what is impacted.


3. **Validation/testing performed**:

   Ran yo office on a Project project to view the new text was output successfully. Also tested the Excel path to confirm no changes.

4. **Platforms tested**:

    > * [x] Windows
    > * [ ] Mac
